### PR TITLE
chore(jobs): drop the "showing most recent 100 jobs" notice

### DIFF
--- a/src/views/JobListView.vue
+++ b/src/views/JobListView.vue
@@ -12,7 +12,7 @@ import RecordDetailsCard from '@/components/Management/RecordDetailsCard.vue'
 import Alert from '@/components/Common/Alert.vue'
 import Badge from '@/components/Common/Badge.vue'
 import type { IJob } from '@/services/fundermaps/interfaces/IJob'
-import { getAllJobs, getJob, JOBS_LIST_LIMIT } from '@/services/fundermaps/endpoints/management/job'
+import { getAllJobs, getJob } from '@/services/fundermaps/endpoints/management/job'
 
 const loading = ref(true)
 const error = ref(false)
@@ -93,9 +93,6 @@ const formatDate = function (date: string | null) {
 
       <Alert v-if="error" :closeable="true" @close="error = false">
         An error occurred while trying to retrieve the list of jobs.
-      </Alert>
-      <Alert v-if="rows.length >= JOBS_LIST_LIMIT" type="danger">
-        Showing the most recent {{ JOBS_LIST_LIMIT }} jobs — older jobs are not loaded.
       </Alert>
       <Vue3Datatable
         :rows="rows"


### PR DESCRIPTION
Removes the danger banner on the Jobs list:

> Showing the most recent 100 jobs — older jobs are not loaded.

Only the `Alert` is removed; the fetch limit is unchanged. `JOBS_LIST_LIMIT` was used solely by that banner, so it's dropped from the view's import (`Alert` stays for the error banner). `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)