### PR TITLE
fix(sessions): show IPv6 addresses in canonical compressed form

### DIFF
--- a/src/views/SessionListView.vue
+++ b/src/views/SessionListView.vue
@@ -152,6 +152,20 @@ const formatDate = function (dateStr: string | null) {
   })
 }
 
+// Canonicalise an IP for display. IPv6 from the proxy arrives fully expanded
+// (e.g. 2a02:a473:7505:0000:0000:0000:0000:0000); the WHATWG URL parser
+// compresses it to RFC 5952 form (2a02:a473:7505::). IPv4 and anything
+// unparseable pass through unchanged.
+const formatIpAddress = function (ip: string | null): string {
+  if (!ip) return '-'
+  if (!ip.includes(':')) return ip
+  try {
+    return new URL(`http://[${ip}]`).hostname.replace(/^\[|\]$/g, '')
+  } catch {
+    return ip
+  }
+}
+
 const renderUserCell = function (userId: string): string {
   const u = userMap.value.get(userId)
   if (!u) return userId
@@ -250,7 +264,7 @@ const renderUserCell = function (userId: string): string {
           </Badge>
         </dd>
         <dt class="font-medium text-grey-700">IP Address</dt>
-        <dd>{{ record.ip_address || '-' }}</dd>
+        <dd>{{ formatIpAddress(record.ip_address) }}</dd>
         <dt class="font-medium text-grey-700">Created</dt>
         <dd>{{ formatDate(record.created_at) }}</dd>
         <dt class="font-medium text-grey-700">Updated</dt>


### PR DESCRIPTION
IPv6 session IPs were shown fully expanded — e.g. `2a02:a473:7505:0000:0000:0000:0000:0000` instead of `2a02:a473:7505::`.

The API stores `session.ipAddress` exactly as the proxy delivers it (expanded), and the session detail panel rendered it verbatim. Added a `formatIpAddress` helper that canonicalizes via the WHATWG URL parser (`new URL('http://[<ip>]').hostname`) — RFC 5952 compression with no bespoke algorithm. IPv4 and unparseable values pass through unchanged.

Only display point is the session detail panel (no IP table column). `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)