### PR TITLE
fix(ui): hide details panel when adding a user/organisation

### DIFF
--- a/src/views/OrganisationListView.vue
+++ b/src/views/OrganisationListView.vue
@@ -138,7 +138,7 @@ const handleDelete = async function () {
     <OrganisationForm v-if="record && showEdit" :record="record" @cancel="handleCloseModal" @saved="refreshList"
       @close="handleCloseModal" />
 
-    <RecordDetailsCard v-if="!showEdit" title="Organisation information" :record="record" :editable="true"
+    <RecordDetailsCard v-if="!showEdit && !showCreate" title="Organisation information" :record="record" :editable="true"
       :deletable="true" emptyMessage="Select an organisation to see details." @edit="handleEdit"
       @delete="handleDelete" @close="handleCloseModal">
       <Alert v-if="actionError" :closeable="true" @close="actionError = null">

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -217,7 +217,7 @@ const handleRoleChange = async function (newRole: string) {
     <EditUserForm v-if="record && showEdit" :record="record" @cancel="handleCloseModal" @saved="refreshList"
       @close="handleCloseModal" />
 
-    <RecordDetailsCard v-if="!showEdit" title="User information" :record="record" :editable="true"
+    <RecordDetailsCard v-if="!showEdit && !showCreate" title="User information" :record="record" :editable="true"
       :deletable="true" emptyMessage="Select a user to see details." @close="handleCloseModal" @edit="handleEdit"
       @delete="handleDelete">
       <Alert v-if="actionError" :closeable="true" @close="actionError = null">


### PR DESCRIPTION
Clicking **Add User** (and **Add organisation**) opened the create form but left the empty details panel mounted next to it.

`RecordDetailsCard` was gated only on `!showEdit`. `handleOpenModal` sets `showCreate=true` (and `record=null`, `showEdit=false`), so the card stayed visible showing its "Select a user…" empty state. Gate it on `!showEdit && !showCreate` so the create form is the only panel.

Same one-line fix in both `UserListView` and `OrganisationListView` (MapsetListView is read-only — no create flow). `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)