### PR TITLE
feat(users): default to a 16-char generated password on create user

### DIFF
--- a/src/components/Management/Forms/CreateUserForm.vue
+++ b/src/components/Management/Forms/CreateUserForm.vue
@@ -34,7 +34,8 @@ onMounted(async () => {
 
 const formData = ref({
   email: '',
-  password: '',
+  // Pre-fill a strong password so the admin can copy it straight away.
+  password: generateStrongPassword(16),
   given_name: '',
   family_name: '',
   organization_id: '',
@@ -83,13 +84,6 @@ const formHandler = async function (formData: {
     )
   }
 }
-
-/**
- * Generates a password and sets it to the password field
- */
-const handleGeneratePassword = () => {
-  formData.value.password = generateStrongPassword()
-}
 </script>
 
 <template>
@@ -112,30 +106,17 @@ const handleGeneratePassword = () => {
       required
     />
 
-    <div class="space-y-2">
-      <div class="flex items-center justify-between">
-        <label for="password" class="text-grey-800 block text-sm font-medium">Password *</label>
-        <button
-          type="button"
-          class="text-xs text-blue-600 hover:text-blue-800"
-          @click="handleGeneratePassword"
-          tabindex="3"
-        >
-          Generate Strong Password
-        </button>
-      </div>
-      <Input
-        id="password"
-        type="text"
-        v-model="formData.password"
-        placeholder="Enter password"
-        :validationStatus="getStatus('password')"
-        :validationMessage="getError('password')"
-        :tabindex="2"
-        required
-        hideLabel
-      />
-    </div>
+    <Input
+      id="password"
+      label="Password *"
+      type="text"
+      v-model="formData.password"
+      placeholder="Enter password"
+      :validationStatus="getStatus('password')"
+      :validationMessage="getError('password')"
+      :tabindex="2"
+      required
+    />
 
     <div class="grid grid-cols-2 gap-4">
       <Select
@@ -145,7 +126,7 @@ const handleGeneratePassword = () => {
         v-model="formData.organization_id"
         :validationStatus="getStatus('organization_id')"
         :validationMessage="getError('organization_id')"
-        :tabindex="4"
+        :tabindex="3"
         required
       />
 
@@ -156,7 +137,7 @@ const handleGeneratePassword = () => {
         v-model="formData.organization_role"
         :validationStatus="getStatus('organization_role')"
         :validationMessage="getError('organization_role')"
-        :tabindex="5"
+        :tabindex="4"
       />
     </div>
 
@@ -169,7 +150,7 @@ const handleGeneratePassword = () => {
         placeholder="Enter given name"
         :validationStatus="getStatus('given_name')"
         :validationMessage="getError('given_name')"
-        :tabindex="6"
+        :tabindex="5"
       />
 
       <Input
@@ -180,7 +161,7 @@ const handleGeneratePassword = () => {
         placeholder="Enter family name"
         :validationStatus="getStatus('family_name')"
         :validationMessage="getError('family_name')"
-        :tabindex="7"
+        :tabindex="6"
       />
     </div>
 
@@ -192,7 +173,7 @@ const handleGeneratePassword = () => {
       placeholder="Enter phone number"
       :validationStatus="getStatus('phone_number')"
       :validationMessage="getError('phone_number')"
-      :tabindex="8"
+      :tabindex="7"
     />
 
     <Input
@@ -203,7 +184,7 @@ const handleGeneratePassword = () => {
       placeholder="Enter job title"
       :validationStatus="getStatus('job_title')"
       :validationMessage="getError('job_title')"
-      :tabindex="9"
+      :tabindex="8"
     />
   </FormCard>
 </template>

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -14,7 +14,7 @@ export const generateStrongPassword = (length = 12): string => {
   password += numbers.charAt(Math.floor(Math.random() * numbers.length))
 
   const allChars = lowercase + uppercase + numbers
-  for (let i = 4; i < length; i++) {
+  for (let i = 3; i < length; i++) {
     password += allChars.charAt(Math.floor(Math.random() * allChars.length))
   }
 


### PR DESCRIPTION
## What

- Pre-fills the create-user password field with a strong **16-character** generated password on form open.
- Removes the now-redundant **"Generate Strong Password"** button and its handler.
- Fixes an off-by-one in `generateStrongPassword()`.

## Why

Admins always set a throwaway initial password anyway, so generating a strong one by default is one less click. With the value pre-filled and the field kept as a visible text input, the admin can read/copy it straight away — making the manual generate button pointless.

## Details

- `CreateUserForm.vue`: `password: generateStrongPassword(16)` as the field default; password block simplified to a plain labelled `Input`; tabindexes renumbered to close the gap left by the removed button.
- `password.ts`: the generation loop started at index `4`, so it emitted `length - 1` characters instead of `length` (the 12-char default produced 11). Now starts at `3`, so the requested length is honored exactly — verified `generateStrongPassword(16)` returns 16 chars and the default returns 12.

## Verification

`pnpm type-check` and `pnpm build` pass. Generated-length checked at runtime (5× 16-char samples, each with mixed case + digits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)