### PR TITLE
feat(users): copy + reveal credentials on create user

### DIFF
--- a/src/components/Management/Forms/CreateUserForm.vue
+++ b/src/components/Management/Forms/CreateUserForm.vue
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import Input from '@/components/Common/Inputs/Input.vue'
 import Select, { type SelectOption } from '@/components/Common/Inputs/Select.vue'
 import FormCard from '@/components/Management/FormCard.vue'
+import CopyToClipboardIcon from '@/components/Common/Icons/CopyToClipboardIcon.vue'
 import { generateStrongPassword } from '@/utils/password.ts'
 
 import { createUser, updateUser } from '@/services/fundermaps/endpoints/management/user.ts'
@@ -11,6 +12,12 @@ import {
   getAllOrganisations,
   addUserToOrganisation,
 } from '@/services/fundermaps/endpoints/management/organisation.ts'
+
+// Surface the created credentials to the parent so it can reveal them once
+// (the generated password is never retrievable after this).
+const emit = defineEmits<{
+  created: [credentials: { email: string; password: string; organisation: string; role: string }]
+}>()
 
 // Org list for the dropdown. The leading empty option is the unselected
 // sentinel — it keeps the native <select> in sync with the empty default
@@ -32,7 +39,7 @@ onMounted(async () => {
   ]
 })
 
-const formData = ref({
+const initialFormData = ref({
   email: '',
   // Pre-fill a strong password so the admin can copy it straight away.
   password: generateStrongPassword(16),
@@ -82,6 +89,15 @@ const formHandler = async function (formData: {
       formData.phone_number,
       '', // avatar
     )
+
+    const organisation =
+      organisationOptions.value.find((o) => o.value === formData.organization_id)?.label ?? ''
+    emit('created', {
+      email: formData.email,
+      password: formData.password,
+      organisation,
+      role: formData.organization_role,
+    })
   }
 }
 </script>
@@ -89,7 +105,7 @@ const formHandler = async function (formData: {
 <template>
   <FormCard
     title="Add User"
-    :form-data="formData"
+    :form-data="initialFormData"
     :validation-schema="validationSchema"
     :formDataHandler="formHandler"
     v-slot="{ formData, getStatus, getError }"
@@ -104,7 +120,11 @@ const formHandler = async function (formData: {
       :validationMessage="getError('email')"
       :tabindex="1"
       required
-    />
+    >
+      <template #after>
+        <CopyToClipboardIcon :value="String(formData.email)" />
+      </template>
+    </Input>
 
     <Input
       id="password"
@@ -116,7 +136,11 @@ const formHandler = async function (formData: {
       :validationMessage="getError('password')"
       :tabindex="2"
       required
-    />
+    >
+      <template #after>
+        <CopyToClipboardIcon :value="String(formData.password)" />
+      </template>
+    </Input>
 
     <div class="grid grid-cols-2 gap-4">
       <Select

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -6,6 +6,7 @@ import '@bhplugin/vue3-datatable/dist/style.css'
 
 import Card from '@/components/Common/Card.vue'
 import Button from '@/components/Common/Buttons/Button.vue'
+import CloseBtn from '@/components/Common/Buttons/CloseBtn.vue'
 import MainWrapper from '@/components/Layout/MainWrapper.vue'
 import RecordDetailsCard from '@/components/Management/RecordDetailsCard.vue'
 import CreateUserForm from '@/components/Management/Forms/CreateUserForm.vue'
@@ -39,6 +40,12 @@ const showEdit = ref(false)
 const actionError = ref<string | null>(null)
 const actionSuccess = ref<string | null>(null)
 const newApiKey = ref<string | null>(null)
+const createdUser = ref<{
+  email: string
+  password: string
+  organisation: string
+  role: string
+} | null>(null)
 
 const flashSuccess = function (message: string) {
   actionSuccess.value = message
@@ -93,6 +100,7 @@ const handleRowClick = async function (row: IUser) {
   actionError.value = null
   actionSuccess.value = null
   newApiKey.value = null
+  createdUser.value = null
   apiKeys.value = []
 
   record.value = await getUser(row.id)
@@ -101,11 +109,26 @@ const handleRowClick = async function (row: IUser) {
 const handleOpenModal = function () {
   showEdit.value = false
   record.value = null
+  createdUser.value = null
   showCreate.value = true
 }
 const handleEdit = function () {
   showCreate.value = false
+  createdUser.value = null
   showEdit.value = true
+}
+
+// Reveal the credentials of a freshly created user once — the generated
+// password is not retrievable afterwards. Closing the create form lets the
+// reveal take its place in the side column.
+const handleUserCreated = function (credentials: {
+  email: string
+  password: string
+  organisation: string
+  role: string
+}) {
+  createdUser.value = credentials
+  showCreate.value = false
 }
 
 // Make sure to reset the form when closing the modal
@@ -116,6 +139,7 @@ const handleCloseModal = function () {
   actionError.value = null
   actionSuccess.value = null
   newApiKey.value = null
+  createdUser.value = null
 }
 
 const handleCreateAPIKey = async function () {
@@ -212,12 +236,45 @@ const handleRoleChange = async function (newRole: string) {
         </template>
       </Vue3Datatable>
     </Card>
-    <CreateUserForm v-if="showCreate" @cancel="handleCloseModal" @saved="refreshList" @close="handleCloseModal" />
+    <CreateUserForm v-if="showCreate" @cancel="handleCloseModal" @saved="refreshList"
+      @created="handleUserCreated" @close="handleCloseModal" />
+
+    <Card v-else-if="createdUser" class="Details col-span-1">
+      <div class="flex items-center justify-between">
+        <h3 class="text-lg font-bold">User created</h3>
+        <CloseBtn label="close" @click="handleCloseModal" />
+      </div>
+      <Alert type="success" class="mt-3">
+        <div class="mb-3 font-medium">
+          Copy these credentials now — the password won't be shown again.
+        </div>
+        <dl class="space-y-3 text-sm">
+          <div class="flex items-center justify-between gap-2">
+            <div class="min-w-0">
+              <dt class="text-grey-700">Email</dt>
+              <dd><code class="select-all break-all">{{ createdUser.email }}</code></dd>
+            </div>
+            <CopyToClipboardIcon :value="createdUser.email" />
+          </div>
+          <div class="flex items-center justify-between gap-2">
+            <div class="min-w-0">
+              <dt class="text-grey-700">Password</dt>
+              <dd><code class="select-all break-all">{{ createdUser.password }}</code></dd>
+            </div>
+            <CopyToClipboardIcon :value="createdUser.password" />
+          </div>
+        </dl>
+        <p class="mt-3 text-grey-700">
+          Added to <span class="font-medium">{{ createdUser.organisation }}</span> as
+          <span class="font-medium">{{ createdUser.role }}</span>.
+        </p>
+      </Alert>
+    </Card>
 
     <EditUserForm v-if="record && showEdit" :record="record" @cancel="handleCloseModal" @saved="refreshList"
       @close="handleCloseModal" />
 
-    <RecordDetailsCard v-if="!showEdit && !showCreate" title="User information" :record="record" :editable="true"
+    <RecordDetailsCard v-if="!showEdit && !showCreate && !createdUser" title="User information" :record="record" :editable="true"
       :deletable="true" emptyMessage="Select a user to see details." @close="handleCloseModal" @edit="handleEdit"
       @delete="handleDelete">
       <Alert v-if="actionError" :closeable="true" @close="actionError = null">


### PR DESCRIPTION
Two QoL improvements to the admin create-user flow.

## 1. Copy buttons on email + password

A `CopyToClipboardIcon` now sits in each field's `#after` slot, so the admin can copy the email and the pre-filled generated password in one click instead of select-and-copy. Reuses the component already used for IDs and API keys.

## 2. Post-create credential reveal

On successful creation the form emits the credentials to `UserListView`, which reveals them once in a success panel — *"Copy these credentials now — the password won't be shown again"* — with copy icons for email and password, and a line showing the org + role the user was added to. This mirrors the existing new-API-key reveal pattern and closes the loop: the generated password isn't retrievable after creation, so the admin needs a moment to grab it before closing.

The reveal takes the create form's place in the side column (the form closes on success); selecting another user, opening the form again, or closing it all clear the reveal.

## Drive-by lint fix

Renames the form-data ref `formData` → `initialFormData` (matching `OrganisationAddUser.vue`). This clears a stale `@typescript-eslint/no-unused-vars` error introduced when PR #24 removed the generate-password handler — the template's `:form-data` binding was shadowed by the `v-slot="{ formData }"` destructure, so the linter couldn't see the ref being used.

## Notes

- No backend or shared-component changes; the shared `Form.vue`/`FormCard.vue` are untouched. (Considered a `#completed` slot there, but mirroring the in-view reveal pattern is more consistent and lower blast-radius.)
- The underlying create → add-to-org → update API sequence was E2E-verified against the live stack in the org-select PR; this change is client-side only and reuses proven components.

## Verification

`pnpm type-check`, `pnpm build`, and `pnpm exec eslint` on both changed files all pass. Diff is scoped to exactly the two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)