### PR TITLE
fix(users): drop copy icons from create-user input fields

### DIFF
--- a/src/components/Management/Forms/CreateUserForm.vue
+++ b/src/components/Management/Forms/CreateUserForm.vue
@@ -4,7 +4,6 @@ import { z } from 'zod'
 import Input from '@/components/Common/Inputs/Input.vue'
 import Select, { type SelectOption } from '@/components/Common/Inputs/Select.vue'
 import FormCard from '@/components/Management/FormCard.vue'
-import CopyToClipboardIcon from '@/components/Common/Icons/CopyToClipboardIcon.vue'
 import { generateStrongPassword } from '@/utils/password.ts'
 
 import { createUser, updateUser } from '@/services/fundermaps/endpoints/management/user.ts'
@@ -120,11 +119,7 @@ const formHandler = async function (formData: {
       :validationMessage="getError('email')"
       :tabindex="1"
       required
-    >
-      <template #after>
-        <CopyToClipboardIcon :value="String(formData.email)" />
-      </template>
-    </Input>
+    />
 
     <Input
       id="password"
@@ -136,11 +131,7 @@ const formHandler = async function (formData: {
       :validationMessage="getError('password')"
       :tabindex="2"
       required
-    >
-      <template #after>
-        <CopyToClipboardIcon :value="String(formData.password)" />
-      </template>
-    </Input>
+    />
 
     <div class="grid grid-cols-2 gap-4">
       <Select


### PR DESCRIPTION
The `CopyToClipboardIcon` added to the email/password `#after` slot didn't render cleanly inside the input field. Removes both (and the now-unused import).

No loss of functionality: the **post-create credential reveal** still shows email + password with working copy buttons, which is the main place an admin needs to copy them.

`pnpm type-check`, `pnpm build`, and eslint on the changed file all pass. Scoped to a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)