### PR TITLE
fix(nav): restore active-link highlight in header

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,8 +18,6 @@ import Callback from '@/views/auth/Callback.vue'
 import NoAccess from '@/views/auth/403.vue'
 
 const router = createRouter({
-  linkActiveClass: 'font-bold',
-  linkExactActiveClass: 'font-bold',
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     /**************************************************************************


### PR DESCRIPTION
## Summary
- The router config was overriding `linkActiveClass` / `linkExactActiveClass` to `'font-bold'`, which replaced Vue Router's default `router-link-active` class on `<RouterLink>`.
- `components/Layout/Header.vue` selects `.nav-link.router-link-active` for the active-item styling (darker text + green underline bar), so with the override in place neither rule ever applied — the active item in the top nav was visually indistinguishable from the others.
- Drop the two overrides. The existing Header CSS now fires, mirroring ClientApp's identical Header behaviour.

`font-bold` isn't referenced for active-link styling anywhere else in the app; `Header.vue` is the only file that touches `router-link-active`.

## Test plan
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — clean (only unrelated rolldown/vueuse warnings)
- [x] `pnpm dev` boots; root page returns HTTP 200
- [ ] Click each top-nav item (Users / Sessions / Organisations / Mapsets / Jobs) and confirm the selected one shows darker text + the green underline bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)