### PR TITLE
fix(ui): polish search input, drawer width, list spacing, FormCard

### DIFF
--- a/src/components/Common/Card.vue
+++ b/src/components/Common/Card.vue
@@ -9,7 +9,7 @@ defineProps({
     <header v-if="title" class="card__header mb-4">
       <h3 class="text-base font-semibold text-grey-800">{{ title }}</h3>
     </header>
-    <div class="card__content space-y-6">
+    <div class="card__content">
       <slot></slot>
     </div>
     <footer v-if="$slots.footer" class="card__footer mt-4">

--- a/src/components/Layout/Drawer.vue
+++ b/src/components/Layout/Drawer.vue
@@ -28,7 +28,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', handleKey))
   <Transition name="drawer">
     <aside
       v-if="open"
-      class="drawer flex w-[28rem] shrink-0 flex-col self-stretch border-l border-grey-200 bg-white"
+      class="drawer flex w-[34rem] shrink-0 flex-col self-stretch border-l border-grey-200 bg-white"
       role="complementary"
     >
       <header

--- a/src/components/Management/FormCard.vue
+++ b/src/components/Management/FormCard.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { type ZodTypeAny } from 'zod'
 
-import CloseBtn from '@/components/Common/Buttons/CloseBtn.vue'
-import Card from '@/components/Common/Card.vue'
 import Form from '@/components/Management/Form.vue'
 
 const emit = defineEmits(['saved', 'cancel'])
@@ -22,20 +20,14 @@ withDefaults(
 </script>
 
 <template>
-  <Card class="Details col-span-1">
-    <div class="flex items-center justify-between">
-      <h3 class="text-lg font-bold">{{ title }}</h3>
-      <CloseBtn label="close" @click="emit('cancel')" />
-    </div>
-    <Form
-      :formDataHandler="formDataHandler"
-      :formData="formData"
-      :validationSchema="validationSchema"
-      @saved="emit('saved')"
-      @cancel="emit('cancel')"
-      v-slot="{ formData, getStatus, getError, loading }"
-    >
-      <slot :formData="formData" :getError="getError" :getStatus="getStatus" :loading="loading" />
-    </Form>
-  </Card>
+  <Form
+    :formDataHandler="formDataHandler"
+    :formData="formData"
+    :validationSchema="validationSchema"
+    @saved="emit('saved')"
+    @cancel="emit('cancel')"
+    v-slot="{ formData, getStatus, getError, loading }"
+  >
+    <slot :formData="formData" :getError="getError" :getStatus="getStatus" :loading="loading" />
+  </Form>
 </template>

--- a/src/styles/components/form/input.css
+++ b/src/styles/components/form/input.css
@@ -38,7 +38,8 @@
       [type="url"],
       [type="password"],
       [type="tel"],
-      [type="number"] {
+      [type="number"],
+      [type="search"] {
         background: url("@assets/svg/icons/validation-success.svg") no-repeat;
         background-size: theme(spacing.3);
         background-position: center right 1rem;
@@ -54,7 +55,8 @@
       [type="url"],
       [type="password"],
       [type="tel"],
-      [type="number"] {
+      [type="number"],
+      [type="search"] {
         @apply text-red-500;
 
         background: url("@assets/svg/icons/validation-error.svg") no-repeat;
@@ -81,7 +83,8 @@
   [type="url"],
   [type="password"],
   [type="tel"],
-  [type="number"] {
+  [type="number"],
+  [type="search"] {
     @apply w-full py-2.5 pl-4 pr-10 text-base leading-none text-blue-900 placeholder-grey-400 focus:outline-none;
 
     &::placeholder {

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -272,24 +272,10 @@ const handleRoleChange = async function (newRole: string) {
               {{ user.role }}
             </Badge>
           </div>
-          <div class="flex items-center gap-2 text-xs text-grey-700">
+          <div class="text-xs text-grey-700">
             <span class="truncate">{{ user.email }}</span>
-            <span aria-hidden="true">·</span>
-            <MonoBadge :value="user.id" />
           </div>
         </div>
-
-        <template #actions>
-          <button
-            type="button"
-            class="button button--ghost"
-            :aria-label="`Copy ID for ${user.email}`"
-            title="Copy ID"
-            @click.stop
-          >
-            <CopyToClipboardIcon :value="user.id" />
-          </button>
-        </template>
       </ListRow>
     </Card>
 


### PR DESCRIPTION
## Summary

Four targeted follow-ups after the PR #30 review.

### 1. Search input looked unstyled
`styles/components/form/input.css` only matched `[type=text|email|url|password|tel|number]`. Search inputs (`<Input type=\"search\">`) fell outside the selector list and got browser default styling — no padding, wrong height, no placeholder color. Added `[type=\"search\"]` to both selector groups (the wrapper and the input itself).

### 2. Forms had double borders
`FormCard` wrapped every form in a `Card` **and** rendered its own title + close button. Inside a drawer body — which already provides border + padding + a title slot + a close button — that produced a nested bordered card with redundant chrome. `FormCard` is now a thin pass-through to `Form` (no Card, no title, no close). The drawer chrome owns those, and the form sits flush in the body.

### 3. Drawer felt cramped on edit forms
Widened the drawer from `w-[28rem]` (448px) to `w-[34rem]` (544px) everywhere. On a 1366px viewport that still leaves ~600px for main content after sidebar + drawer.

### 4. Extra space between rows in the Users list
`Card.vue` had a default `space-y-6` on its body slot, which put 24px gaps between every `ListRow` in `UserListView`. Removed the default — consumers add spacing where they actually want it (forms have their own `space-y-4` inside `Form`, etc.).

### 5. Drop User ID from the Users list rows
Too technical for the list view. The ID is still visible (as a `MonoBadge`) in the drawer details panel. Also dropped the copy-ID ghost button that was paired with it.

## Test plan
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` on touched files — clean
- [x] `pnpm build` — clean
- [x] Dev server boots; root HTTP 200
- [ ] **Manual:**
  - Users / Orgs / Mapsets pages: search bar matches text-input height + padding.
  - Click any user → drawer opens at 34rem; details fields not cramped.
  - Click Add organisation → form sits flush in the drawer body (no nested card / double border).
  - Click any user row in the Users list: no 24px gap between rows; row no longer shows the ID badge or copy button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)