### PR TITLE
fix(auth): recover from a failed SSO callback instead of looping

### DIFF
--- a/src/views/auth/Callback.vue
+++ b/src/views/auth/Callback.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import { useRoute, useRouter, RouterLink } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
-import { exchangeCode } from '@/services/oidc'
+import { exchangeCode, logoutRedirect } from '@/services/oidc'
 import { useSessionStore } from '@/stores/session'
 
 const route = useRoute()
@@ -27,14 +27,24 @@ onMounted(async () => {
     error.value = true
   }
 })
+
+// End the SSO session at the provider, then land on /login for a fresh sign-in.
+// A plain link back to /login would silently re-authenticate via the still-alive
+// SSO session — straight back into the same account (which, if it lacks admin
+// access, loops back to this error). RP-initiated logout breaks that. See oidc.ts.
+function signOut() {
+  logoutRedirect()
+}
 </script>
 
 <template>
   <!-- Neutral loading during the code exchange — not the login chrome. -->
-  <div class="grid min-h-screen place-content-center text-grey-700">
+  <div class="grid min-h-screen place-content-center text-center text-grey-700">
     <p v-if="error" class="text-sm">
-      Login failed.
-      <RouterLink :to="{ name: 'login' }" class="text-green-700 underline">Try again</RouterLink>
+      Login failed. The active account may not have access to this app.
+      <button type="button" class="text-green-700 underline" @click="signOut">
+        Sign in with a different account
+      </button>
     </p>
     <p v-else class="text-sm">Signing in…</p>
   </div>


### PR DESCRIPTION
Part of #990 (fleet-wide consistency with the ClientApp fix).

The OIDC callback error path showed "Login failed" with a *Try again* link to `/login`. Because the SSO session is still alive, that link silently re-authenticates as the **same** account and loops back to the error (and for a non-admin account, straight to /403).

**Fix:** the recovery action now does an RP logout (`logoutRedirect`), ending the SSO session so the user gets a real login prompt and can sign in with a different account. Message clarified too.

Type-checks clean. No backend/DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)