### PR TITLE
feat(ui): dock the detail panel and auto-select the first row

### DIFF
--- a/src/components/Layout/Drawer.vue
+++ b/src/components/Layout/Drawer.vue
@@ -1,69 +1,29 @@
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount } from 'vue'
-
-import ChevronRightIcon from '@assets/svg/icons/chevron-right.svg'
-
-const props = withDefaults(
+withDefaults(
   defineProps<{
-    open?: boolean
     title?: string
   }>(),
   {
-    open: true,
     title: '',
   },
 )
-
-const emit = defineEmits<{ close: [] }>()
-
-const handleKey = (e: KeyboardEvent) => {
-  if (e.key === 'Escape' && props.open) emit('close')
-}
-
-onMounted(() => window.addEventListener('keydown', handleKey))
-onBeforeUnmount(() => window.removeEventListener('keydown', handleKey))
 </script>
 
 <template>
-  <Transition name="drawer">
-    <aside
-      v-if="open"
-      class="drawer flex w-[34rem] shrink-0 flex-col self-stretch border-l border-grey-200 bg-white"
-      role="complementary"
-    >
-      <header
-        class="flex h-14 shrink-0 items-center gap-3 border-b border-grey-200 pl-2 pr-4"
-      >
-        <button
-          type="button"
-          class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded text-grey-700 transition-colors hover:bg-grey-100 hover:text-grey-800"
-          aria-label="Close panel"
-          title="Close panel (Esc)"
-          @click="emit('close')"
-        >
-          <ChevronRightIcon class="aspect-square h-4" aria-hidden="true" />
-        </button>
-        <h3 class="min-w-0 flex-1 truncate text-sm font-semibold text-grey-800">
-          <slot name="title">{{ title }}</slot>
-        </h3>
-        <div v-if="$slots.actions" class="flex shrink-0 items-center gap-1.5">
-          <slot name="actions" />
-        </div>
-      </header>
-      <div class="flex-1 overflow-y-auto p-4">
-        <slot />
+  <aside
+    class="drawer flex w-[34rem] shrink-0 flex-col self-stretch border-l border-grey-200 bg-white"
+    role="complementary"
+  >
+    <header class="flex h-14 shrink-0 items-center gap-3 border-b border-grey-200 px-4">
+      <h3 class="min-w-0 flex-1 truncate text-sm font-semibold text-grey-800">
+        <slot name="title">{{ title }}</slot>
+      </h3>
+      <div v-if="$slots.actions" class="flex shrink-0 items-center gap-1.5">
+        <slot name="actions" />
       </div>
-    </aside>
-  </Transition>
+    </header>
+    <div class="flex-1 overflow-y-auto p-4">
+      <slot />
+    </div>
+  </aside>
 </template>
-
-<style scoped>
-.drawer-enter-active,
-.drawer-leave-active {
-  transition: transform 200ms ease;
-}
-.drawer-enter-from,
-.drawer-leave-to {
-  transform: translateX(100%);
-}
-</style>

--- a/src/views/JobListView.vue
+++ b/src/views/JobListView.vue
@@ -38,8 +38,6 @@ const refreshList = async function () {
   }
 }
 
-onBeforeMount(refreshList)
-
 const handleSelect = async function (row: IJob) {
   record.value = row
   try {
@@ -48,9 +46,16 @@ const handleSelect = async function (row: IJob) {
     console.error('Failed to refetch job, using row data', e)
   }
 }
-const handleCloseDrawer = function () {
-  record.value = null
+
+const selectFirstRow = function () {
+  const first = rows.value[0]
+  if (first) handleSelect(first)
 }
+
+onBeforeMount(async () => {
+  await refreshList()
+  selectFirstRow()
+})
 
 const statusVariant = function (
   status: string,
@@ -107,7 +112,7 @@ const formatDate = function (date: string | null) {
     </Table>
 
     <template #aside>
-      <Drawer :open="!!record" @close="handleCloseDrawer">
+      <Drawer>
         <template #title>Job information</template>
         <template v-if="record">
           <dl class="grid grid-cols-[8rem_1fr] gap-x-4 gap-y-2 text-sm">
@@ -142,6 +147,12 @@ const formatDate = function (date: string | null) {
             >
           </div>
         </template>
+        <div
+          v-else
+          class="flex h-full items-center justify-center text-center text-sm text-grey-700"
+        >
+          No jobs to show.
+        </div>
       </Drawer>
     </template>
   </MainWrapper>

--- a/src/views/MapsetListView.vue
+++ b/src/views/MapsetListView.vue
@@ -53,8 +53,6 @@ const refreshList = async function () {
   }
 }
 
-onBeforeMount(refreshList)
-
 const handleSelect = function (row: IMapset) {
   if (record.value?.id !== row.id) {
     activeTab.value = 'info'
@@ -62,9 +60,15 @@ const handleSelect = function (row: IMapset) {
   record.value = row
 }
 
-const handleCloseDrawer = function () {
-  record.value = null
+const selectFirstRow = function () {
+  const first = filteredRows.value[0]
+  if (first) handleSelect(first)
 }
+
+onBeforeMount(async () => {
+  await refreshList()
+  selectFirstRow()
+})
 
 const handleLayersSaved = async function (updated: IMapset) {
   record.value = updated
@@ -126,7 +130,7 @@ const handleLayersSaved = async function (updated: IMapset) {
     </Table>
 
     <template #aside>
-      <Drawer :open="!!record" @close="handleCloseDrawer">
+      <Drawer>
         <template #title>Mapset information</template>
         <template v-if="record">
           <MapsetTabs v-model="activeTab" />
@@ -154,6 +158,12 @@ const handleLayersSaved = async function (updated: IMapset) {
             <MapsetLayersSection :record="record" @saved="handleLayersSaved" />
           </div>
         </template>
+        <div
+          v-else
+          class="flex h-full items-center justify-center text-center text-sm text-grey-700"
+        >
+          No mapsets to display.
+        </div>
       </Drawer>
     </template>
   </MainWrapper>

--- a/src/views/OrganisationListView.vue
+++ b/src/views/OrganisationListView.vue
@@ -71,8 +71,6 @@ const refreshList = async function () {
   }
 }
 
-onBeforeMount(refreshList)
-
 const handleSelect = function (row: IOrg) {
   showCreate.value = false
   showEdit.value = false
@@ -83,17 +81,26 @@ const handleSelect = function (row: IOrg) {
   record.value = row
 }
 
+const selectFirstRow = function () {
+  const first = filteredRows.value[0]
+  if (first) handleSelect(first)
+}
+
+onBeforeMount(async () => {
+  await refreshList()
+  selectFirstRow()
+})
+
 const handleOpenCreate = function () {
   showEdit.value = false
-  record.value = null
   showCreate.value = true
 }
 
-const handleCloseDrawer = function () {
+const handleDismissForm = function () {
   showCreate.value = false
   showEdit.value = false
-  record.value = null
   actionError.value = null
+  if (!record.value) selectFirstRow()
 }
 
 const handleEdit = function () {
@@ -111,6 +118,7 @@ const handleDelete = async function () {
     record.value = null
     showEdit.value = false
     await refreshList()
+    selectFirstRow()
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to delete organisation.'
   }
@@ -165,7 +173,7 @@ const handleDelete = async function () {
     </Table>
 
     <template #aside>
-      <Drawer :open="drawerMode !== null" @close="handleCloseDrawer">
+      <Drawer>
         <template #title>
           <template v-if="drawerMode === 'create'">New organisation</template>
           <template v-else-if="drawerMode === 'edit'">Edit {{ record?.name }}</template>
@@ -179,17 +187,17 @@ const handleDelete = async function () {
 
         <CreateOrganisationForm
           v-if="drawerMode === 'create'"
-          @cancel="handleCloseDrawer"
+          @cancel="handleDismissForm"
           @saved="refreshList"
-          @close="handleCloseDrawer"
+          @close="handleDismissForm"
         />
 
         <OrganisationForm
           v-else-if="drawerMode === 'edit' && record"
           :record="record"
-          @cancel="handleCloseDrawer"
+          @cancel="handleDismissForm"
           @saved="refreshList"
-          @close="handleCloseDrawer"
+          @close="handleDismissForm"
         />
 
         <div v-else-if="drawerMode === 'details' && record" class="space-y-4">
@@ -217,6 +225,13 @@ const handleDelete = async function () {
           <div v-else-if="activeTab === 'geolock'">
             <OrganisationGeolockSection :record="record" />
           </div>
+        </div>
+
+        <div
+          v-else
+          class="flex h-full items-center justify-center text-center text-sm text-grey-700"
+        >
+          No organisations to display.
         </div>
       </Drawer>
     </template>

--- a/src/views/SessionListView.vue
+++ b/src/views/SessionListView.vue
@@ -94,6 +94,7 @@ const loadUsers = async function () {
 
 onBeforeMount(async () => {
   await Promise.all([refreshList(), loadUsers()])
+  selectFirstRow()
   // Tick once a minute — sessions are minute-grained; second-resolution
   // would re-render the whole table for no real benefit.
   clockHandle = setInterval(() => {
@@ -101,7 +102,10 @@ onBeforeMount(async () => {
   }, 60_000)
 })
 
-watch(userIdFilter, refreshList)
+watch(userIdFilter, async () => {
+  await refreshList()
+  selectFirstRow()
+})
 
 onBeforeUnmount(() => {
   if (clockHandle !== null) clearInterval(clockHandle)
@@ -113,10 +117,9 @@ const handleSelect = function (row: ISession) {
   record.value = row
 }
 
-const handleCloseDrawer = function () {
-  record.value = null
-  actionError.value = null
-  actionSuccess.value = null
+const selectFirstRow = function () {
+  const first = rows.value[0]
+  if (first) handleSelect(first)
 }
 
 const handleClearUserFilter = function () {
@@ -133,8 +136,9 @@ const handleForceLogout = async function () {
     actionError.value = null
     await deleteSession(record.value.id)
     record.value = null
-    flashSuccess('Session terminated.')
     await refreshList()
+    selectFirstRow()
+    flashSuccess('Session terminated.')
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to terminate session.'
   }
@@ -235,7 +239,7 @@ const renderUserCell = function (userId: string): string {
     </Table>
 
     <template #aside>
-      <Drawer :open="!!record" @close="handleCloseDrawer">
+      <Drawer>
         <template #title>Session information</template>
         <template v-if="record" #actions>
           <Button danger label="Terminate" @click="handleForceLogout" />
@@ -277,6 +281,12 @@ const renderUserCell = function (userId: string): string {
             <p class="break-all text-sm text-grey-800">{{ record.user_agent }}</p>
           </div>
         </template>
+        <div
+          v-else
+          class="flex h-full items-center justify-center text-center text-sm text-grey-700"
+        >
+          No active sessions.
+        </div>
       </Drawer>
     </template>
   </MainWrapper>

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -110,8 +110,6 @@ const refreshList = async function () {
   }
 }
 
-onBeforeMount(refreshList)
-
 const handleSelect = async function (row: IUser) {
   showCreate.value = false
   showEdit.value = false
@@ -124,9 +122,18 @@ const handleSelect = async function (row: IUser) {
   ;[record.value, apiKeys.value] = await Promise.all([getUser(row.id), getAPIKeys(row.id)])
 }
 
+const selectFirstRow = function () {
+  const first = filteredRows.value[0]
+  if (first) handleSelect(first)
+}
+
+onBeforeMount(async () => {
+  await refreshList()
+  selectFirstRow()
+})
+
 const handleOpenCreate = function () {
   showEdit.value = false
-  record.value = null
   createdUser.value = null
   showCreate.value = true
 }
@@ -147,14 +154,14 @@ const handleUserCreated = function (credentials: {
   showCreate.value = false
 }
 
-const handleCloseDrawer = function () {
+const handleDismissForm = function () {
   showCreate.value = false
   showEdit.value = false
-  record.value = null
   actionError.value = null
   actionSuccess.value = null
   newApiKey.value = null
   createdUser.value = null
+  if (!record.value) selectFirstRow()
 }
 
 const handleCreateAPIKey = async function () {
@@ -195,6 +202,7 @@ const handleDelete = async function () {
     record.value = null
     showEdit.value = false
     await refreshList()
+    selectFirstRow()
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to delete user.'
   }
@@ -280,7 +288,7 @@ const handleRoleChange = async function (newRole: string) {
     </Card>
 
     <template #aside>
-      <Drawer :open="drawerMode !== null" @close="handleCloseDrawer">
+      <Drawer>
         <template #title>
           <template v-if="drawerMode === 'create'">New user</template>
           <template v-else-if="drawerMode === 'created'">User created</template>
@@ -296,10 +304,10 @@ const handleRoleChange = async function (newRole: string) {
         <!-- Create -->
         <CreateUserForm
           v-if="drawerMode === 'create'"
-          @cancel="handleCloseDrawer"
+          @cancel="handleDismissForm"
           @saved="refreshList"
           @created="handleUserCreated"
-          @close="handleCloseDrawer"
+          @close="handleDismissForm"
         />
 
         <!-- Credentials reveal -->
@@ -329,15 +337,18 @@ const handleRoleChange = async function (newRole: string) {
             Added to <span class="font-medium">{{ createdUser.organisation }}</span> as
             <span class="font-medium">{{ createdUser.role }}</span>.
           </p>
+          <div class="mt-4 flex justify-end">
+            <Button outline label="Done" @click="handleDismissForm" />
+          </div>
         </Alert>
 
         <!-- Edit -->
         <EditUserForm
           v-else-if="drawerMode === 'edit' && record"
           :record="record"
-          @cancel="handleCloseDrawer"
+          @cancel="handleDismissForm"
           @saved="refreshList"
-          @close="handleCloseDrawer"
+          @close="handleDismissForm"
         />
 
         <!-- Details -->
@@ -439,6 +450,13 @@ const handleRoleChange = async function (newRole: string) {
               </div>
             </div>
           </section>
+        </div>
+
+        <div
+          v-else
+          class="flex h-full items-center justify-center text-center text-sm text-grey-700"
+        >
+          No users to display.
         </div>
       </Drawer>
     </template>


### PR DESCRIPTION
## What

The right-hand detail panel no longer slides in and out. On every list view it is now **always docked**, and the **first row is auto-selected on load** so its details are shown immediately for view/edit — no more empty page until you click.

## Changes

- **`Drawer.vue`** — removed the `open` prop, slide transition, Esc handler, and chevron close button. It is now a permanently docked presentational panel (`title` slot + `actions` slot + body).
- **All five views** (Users, Organisations, Mapsets, Jobs, Sessions):
  - Auto-select the first row on load.
  - Re-select the first remaining row after a delete/terminate.
  - Centered placeholder for the empty-list case.
- **Create/edit** no longer wipe the current selection — cancelling returns you to the record you were on (or the first row).
- Added a **Done** button to the user-created credentials reveal (it had relied on the now-removed chevron to dismiss).
- **Sessions** — reordered the terminate flow so the "Session terminated" flash survives the auto-reselect.

## Verification

`pnpm type-check`, `eslint`, `pnpm build`, and Vite transform of all changed SFCs all pass. Authenticated visual click-through was not run (local Better Auth has no `localhost:5173` redirect URI for the `managementfront` client); static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
