### PR TITLE
feat(ui): show user organisation memberships as a keys-style list

### DIFF
--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -345,16 +345,23 @@ const handleRoleChange = async function (newRole: string) {
             <dd class="text-grey-800">{{ record.job_title || '—' }}</dd>
           </dl>
 
-          <section v-if="record.organizations?.length">
+          <section>
             <h6 class="mb-2 text-xs font-semibold uppercase tracking-wide text-grey-700">
               Organisations
             </h6>
-            <ul class="space-y-1 text-sm text-grey-800">
-              <li v-for="org in record.organizations" :key="org.id" class="flex items-center gap-2">
-                <span>{{ org.name }}</span>
+            <div v-if="!record.organizations?.length" class="text-xs text-grey-700">
+              Not a member of any organisation.
+            </div>
+            <div v-else class="overflow-hidden rounded-md border border-grey-200">
+              <div
+                v-for="org in record.organizations"
+                :key="org.id"
+                class="flex items-center justify-between gap-3 border-b border-grey-200 px-3 py-2 text-sm last:border-b-0 hover:bg-grey-100"
+              >
+                <span class="min-w-0 flex-1 truncate font-medium text-grey-800">{{ org.name }}</span>
                 <MonoBadge :value="org.id" />
-              </li>
-            </ul>
+              </div>
+            </div>
           </section>
 
           <section>


### PR DESCRIPTION
## What

Show, per user, the organisations they belong to — styled like the API-keys list.

The user detail panel already listed organisations, but as a plain bullet list. This restyles it into the same bordered-row pattern as the API keys section: **org name on the left, id badge on the right**, with a hover state and a `Not a member of any organisation.` empty state.

## Notes

- **Pure template change** in `UserListView.vue` — no backend/types touched. The data (`IUser.organizations`) was already returned by `getUser`.
- **Read-only.** `IOrganization` is only `{ id, name }`, so there's no per-org role to show, and membership is still managed from the Organisation side (add/remove user). No "leave org" action here.

## Verification

`pnpm build` + `eslint` pass; styling verified against the keys list via a headless-Chromium render (populated + empty states). No authenticated click-through (OIDC localhost gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
