### PR TITLE
feat(ui): show membership role on a user's organisation list

### DIFF
--- a/src/services/fundermaps/interfaces/IOrganization.ts
+++ b/src/services/fundermaps/interfaces/IOrganization.ts
@@ -1,4 +1,6 @@
 export interface IOrganization {
   id: string
   name: string
+  /** The user's membership role within this organisation (reader/writer/verifier/superuser). Present on a user's organisation list. */
+  role?: string | null
 }

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -359,6 +359,9 @@ const handleRoleChange = async function (newRole: string) {
                 class="flex items-center justify-between gap-3 border-b border-grey-200 px-3 py-2 text-sm last:border-b-0 hover:bg-grey-100"
               >
                 <span class="min-w-0 flex-1 truncate font-medium text-grey-800">{{ org.name }}</span>
+                <Badge v-if="org.role" :variant="org.role === 'superuser' ? 'info' : 'default'">
+                  {{ org.role }}
+                </Badge>
                 <MonoBadge :value="org.id" />
               </div>
             </div>


### PR DESCRIPTION
Adds the membership **role** badge (reader/writer/verifier/superuser) to each row in the user detail panel's Organisations list, next to the org name and id.

Depends on **FunderMapsApi#65** for the `role` data. `org.role` is optional and the badge is `v-if`-gated, so this is safe to merge/deploy independently — it simply shows nothing extra until the API ships the field. Once #65 deploys, the org list (which is also currently empty due to that bug) populates with names + roles.

Verified: `pnpm build` + `eslint` pass; rendered the row layout (incl. superuser highlight) via headless Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)