### PR TITLE
feat(ui): Jobs overhaul — filter, search, cancel, duration, auto-refresh

### DIFF
--- a/src/services/fundermaps/endpoints/management/job.ts
+++ b/src/services/fundermaps/endpoints/management/job.ts
@@ -1,16 +1,25 @@
-import { get } from '../../client'
+import { get, post } from '../../client'
 import type { IJob } from '../../interfaces/IJob'
 
 export const JOBS_LIST_LIMIT = 100
 
-export const getAllJobs = async function getAllJobs(): Promise<IJob[]> {
-  return await get({
-    endpoint: `management/jobs?limit=${JOBS_LIST_LIMIT}`,
-  })
+export const getAllJobs = async function getAllJobs(opts?: {
+  status?: string
+  jobType?: string
+}): Promise<IJob[]> {
+  const params = new URLSearchParams({ limit: String(JOBS_LIST_LIMIT) })
+  if (opts?.status) params.set('status', opts.status)
+  if (opts?.jobType) params.set('job_type', opts.jobType)
+  return await get({ endpoint: `management/jobs?${params.toString()}` })
 }
 
 export const getJob = async function getJob(jobId: number): Promise<IJob> {
   return await get({
     endpoint: `management/jobs/${jobId}`,
   })
+}
+
+/** Cancel a pending or retry job (server marks it failed with "Cancelled by admin"). */
+export const cancelJob = async function cancelJob(jobId: number): Promise<IJob> {
+  return await post({ endpoint: `management/jobs/${jobId}/cancel` })
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -11,6 +11,35 @@ export const formatDate = (date: string | null): string =>
   date ? new Date(date).toLocaleString('en-GB', DATE_FORMAT) : '—'
 
 /**
+ * Human-readable elapsed time between two ISO timestamps (or "—" if either is
+ * missing / negative). Coarse-grained: seconds → minutes → hours → days.
+ */
+export const formatDuration = (from: string | null, to: string | null): string => {
+  if (!from || !to) return '—'
+  const ms = new Date(to).getTime() - new Date(from).getTime()
+  if (!Number.isFinite(ms) || ms < 0) return '—'
+
+  const seconds = Math.floor(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) {
+    const s = seconds % 60
+    return s ? `${minutes}m ${s}s` : `${minutes}m`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    const m = minutes % 60
+    return m ? `${hours}h ${m}m` : `${hours}h`
+  }
+
+  const days = Math.floor(hours / 24)
+  const h = hours % 24
+  return h ? `${days}d ${h}h` : `${days}d`
+}
+
+/**
  * Human-readable time remaining until `expiresAt`, relative to `now` (ms since
  * epoch). Coarse-grained (minutes/hours/days) — callers typically tick `now`
  * once a minute, so finer units would just look stale.

--- a/src/views/JobListView.vue
+++ b/src/views/JobListView.vue
@@ -1,34 +1,94 @@
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
 import MainWrapper from '@/components/Layout/MainWrapper.vue'
 import Drawer from '@/components/Layout/Drawer.vue'
 import Table from '@/components/Common/Table.vue'
 import Alert from '@/components/Common/Alert.vue'
 import Badge from '@/components/Common/Badge.vue'
 import MonoBadge from '@/components/Common/MonoBadge.vue'
+import Input from '@/components/Common/Inputs/Input.vue'
+import Select from '@/components/Common/Inputs/Select.vue'
+import Button from '@/components/Common/Buttons/Button.vue'
 import type { IJob } from '@/services/fundermaps/interfaces/IJob'
-import { getAllJobs, getJob } from '@/services/fundermaps/endpoints/management/job'
-import { formatDate } from '@/utils/date'
+import {
+  cancelJob,
+  getAllJobs,
+  getJob,
+  JOBS_LIST_LIMIT,
+} from '@/services/fundermaps/endpoints/management/job'
+import { formatDate, formatDuration } from '@/utils/date'
 import { useListResource } from '@/composables/useListResource'
+import { useFlash } from '@/composables/useFlash'
+import { getErrorMessage } from '@/services/fundermaps/errors'
+
+const statusFilter = ref('')
+const actionError = ref<string | null>(null)
+const { message: actionSuccess, flash: flashSuccess } = useFlash()
+
+const STATUS_OPTIONS = [
+  { label: 'All statuses', value: '' },
+  { label: 'Pending', value: 'pending' },
+  { label: 'Processing', value: 'processing' },
+  { label: 'Retry', value: 'retry' },
+  { label: 'Failed', value: 'failed' },
+  { label: 'Completed', value: 'completed' },
+]
 
 const columns = [
   { field: 'id', title: 'ID', width: '5rem' },
   { field: 'job_type', title: 'Type' },
   { field: 'status', title: 'Status', width: '7rem' },
-  { field: 'priority', title: 'Priority', width: '5rem', align: 'right' as const },
-  { field: 'created_at', title: 'Created', width: '13rem' },
+  { field: 'retries', title: 'Retries', width: '6rem', align: 'right' as const },
+  { field: 'duration', title: 'Duration', width: '7rem', align: 'right' as const },
+  { field: 'created_at', title: 'Created', width: '12rem' },
 ]
 
-const { rows, loading, error, record, select: handleSelect } = useListResource<IJob>({
-  fetch: async () => (await getAllJobs()).sort((a, b) => b.id - a.id),
-  resolve: async (row) => {
-    try {
-      return await getJob(row.id)
-    } catch (e) {
-      console.error('Failed to refetch job, using row data', e)
-      return row
-    }
-  },
+const {
+  rows,
+  loading,
+  error,
+  search,
+  record,
+  filteredRows,
+  refresh,
+  refreshAndSelectFirst,
+  select: handleSelect,
+} = useListResource<IJob>({
+    fetch: async () =>
+      (await getAllJobs({ status: statusFilter.value || undefined })).sort((a, b) => b.id - a.id),
+    filter: (j, q) =>
+      String(j.id).includes(q) ||
+      j.job_type.toLowerCase().includes(q) ||
+      j.status.toLowerCase().includes(q) ||
+      (j.last_error ?? '').toLowerCase().includes(q),
+    resolve: async (row) => {
+      try {
+        return await getJob(row.id)
+      } catch (e) {
+        console.error('Failed to refetch job, using row data', e)
+        return row
+      }
+    },
+  })
+
+// Re-fetch from the server when the status filter changes, landing on the
+// first match so the panel reflects the new filter.
+watch(statusFilter, () => refreshAndSelectFirst())
+
+// Jobs is a live queue — poll the list so statuses stay current. Selection
+// (which fetches its own detail) is left untouched.
+let pollHandle: ReturnType<typeof setInterval> | null = null
+onMounted(() => {
+  pollHandle = setInterval(() => refresh(), 10_000)
 })
+onBeforeUnmount(() => {
+  if (pollHandle !== null) clearInterval(pollHandle)
+})
+
+const onStatusChange = (value: unknown) => {
+  statusFilter.value = String(value ?? '')
+}
 
 const statusVariant = function (
   status: string,
@@ -46,25 +106,75 @@ const statusVariant = function (
       return 'default'
   }
 }
+
+// Lifecycle time for finished jobs (queued → finished). Running/queued jobs
+// have no meaningful end yet.
+const jobDuration = (job: IJob): string =>
+  job.status === 'completed' || job.status === 'failed'
+    ? formatDuration(job.created_at, job.updated_at)
+    : '—'
+
+const canCancel = (job: IJob | null): boolean =>
+  !!job && (job.status === 'pending' || job.status === 'retry')
+
+const handleCancel = async function () {
+  if (!record.value) return
+  if (!confirm(`Cancel job #${record.value.id}? It will be marked as failed.`)) return
+
+  try {
+    actionError.value = null
+    record.value = await cancelJob(record.value.id)
+    await refresh()
+    flashSuccess('Job cancelled.')
+  } catch (e) {
+    actionError.value = getErrorMessage(e) ?? 'Failed to cancel job.'
+  }
+}
 </script>
 
 <template>
   <MainWrapper>
     <header class="mb-4">
       <h2 class="text-xl font-semibold text-grey-800">Jobs</h2>
-      <p class="mt-0.5 text-sm text-grey-700">Background jobs, ordered by most recent.</p>
+      <p class="mt-0.5 text-sm text-grey-700">
+        Background jobs, newest first. The list refreshes automatically.
+      </p>
     </header>
+
+    <div class="mb-3 flex items-center gap-3">
+      <div class="w-72">
+        <Input
+          id="job-search"
+          v-model="search"
+          type="search"
+          placeholder="Search by ID, type, status or error…"
+        />
+      </div>
+      <div class="w-44">
+        <Select
+          id="job-status"
+          :options="STATUS_OPTIONS"
+          :modelValue="statusFilter"
+          @update:modelValue="onStatusChange"
+        />
+      </div>
+      <span class="text-xs text-grey-700">{{ filteredRows.length }} of {{ rows.length }}</span>
+    </div>
 
     <Alert v-if="error" :closeable="true" class="mb-3" @close="error = false">
       An error occurred while trying to retrieve the list of jobs.
     </Alert>
+    <Alert v-if="rows.length >= JOBS_LIST_LIMIT" type="warning" class="mb-3">
+      Showing the first {{ JOBS_LIST_LIMIT }} jobs — narrow the list with a status filter to see
+      more.
+    </Alert>
 
     <Table
-      :rows="rows"
+      :rows="filteredRows"
       :columns="columns"
       :loading="loading"
       :selectedId="record?.id"
-      emptyMessage="No jobs to show."
+      emptyMessage="No jobs match your filters."
       @select="handleSelect"
     >
       <template #id="{ row }">
@@ -76,13 +186,41 @@ const statusVariant = function (
       <template #status="{ row }">
         <Badge :variant="statusVariant(row.status)">{{ row.status }}</Badge>
       </template>
+      <template #retries="{ row }">
+        <span
+          class="font-mono text-xs"
+          :class="row.retry_count > 0 ? 'text-grey-800' : 'text-grey-700'"
+        >
+          {{ row.retry_count }}/{{ row.max_retries }}
+        </span>
+      </template>
+      <template #duration="{ row }">
+        <span class="font-mono text-xs text-grey-700">{{ jobDuration(row) }}</span>
+      </template>
       <template #created_at="{ row }">{{ formatDate(row.created_at) }}</template>
     </Table>
 
     <template #aside>
       <Drawer>
         <template #title>Job information</template>
+        <template v-if="record && canCancel(record)" #actions>
+          <Button danger label="Cancel job" @click="handleCancel" />
+        </template>
+
         <template v-if="record">
+          <Alert v-if="actionError" :closeable="true" class="mb-3" @close="actionError = null">
+            {{ actionError }}
+          </Alert>
+          <Alert
+            v-if="actionSuccess"
+            type="success"
+            :closeable="true"
+            class="mb-3"
+            @close="actionSuccess = null"
+          >
+            {{ actionSuccess }}
+          </Alert>
+
           <dl class="grid grid-cols-[8rem_1fr] gap-x-4 gap-y-2 text-sm">
             <dt class="text-grey-700">ID</dt>
             <dd><MonoBadge :value="`#${record.id}`" /></dd>
@@ -96,6 +234,8 @@ const statusVariant = function (
             <dd class="text-grey-800">{{ record.priority }}</dd>
             <dt class="text-grey-700">Retries</dt>
             <dd class="text-grey-800">{{ record.retry_count }} / {{ record.max_retries }}</dd>
+            <dt class="text-grey-700">Duration</dt>
+            <dd class="text-grey-800">{{ jobDuration(record) }}</dd>
             <dt class="text-grey-700">Last error</dt>
             <dd class="text-grey-800">{{ record.last_error || '—' }}</dd>
             <dt class="text-grey-700">Process after</dt>


### PR DESCRIPTION
## What

The Jobs view was the weakest spot — read-only, no filtering, silently capped at 100, no controls. This wires up capabilities the API **already supported** but the UI never used.

- **Filter by status** (server-side `?status=`) + **free-text search** (id / type / status / error message).
- **Cancel** a pending/retry job (`POST /management/jobs/:id/cancel`).
- **Retries** (`n/max`) and **Duration** (queued → finished) columns, plus a Duration row in the detail.
- **"Showing first 100" warning** — it truncated silently before (Users already had this).
- **Auto-refresh** every 10s (it's a live queue); polling preserves the current selection, while changing the status filter re-fetches and lands on the first match.

## Layer changes
- `getAllJobs(opts?)` now accepts `status`/`jobType` filters; added `cancelJob`.
- `formatDuration(from, to)` added to `utils/date.ts`.

## Verification
`pnpm build` (type-check + bundle) + `eslint` pass. E2E against the live API: status filter returns correctly-scoped results (`completed`/`failed` verified). Live **cancel** wasn't exercised — no pending/retry job exists in the dev DB and the worker is running, so I didn't fabricate one; the wiring follows the same proven action pattern as the other mutations. No authenticated SPA click-through (OIDC localhost gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)