### PR TITLE
feat(ui): list QoL — sessions search/columns, mapset layer count, user→sessions link

### DIFF
--- a/src/utils/userAgent.ts
+++ b/src/utils/userAgent.ts
@@ -1,0 +1,18 @@
+/**
+ * Best-effort, human-readable client name from a User-Agent string — enough to
+ * tell a browser session from an API client at a glance. Order matters: Edge
+ * and Chrome UA strings also contain "Safari"/"Chrome", so check the more
+ * specific tokens first.
+ */
+export const describeClient = (ua: string | null): string => {
+  if (!ua) return '—'
+  const s = ua.toLowerCase()
+  if (s.includes('edg/') || s.includes('edga/') || s.includes('edgios/')) return 'Edge'
+  if (s.includes('firefox') || s.includes('fxios')) return 'Firefox'
+  if (s.includes('chrome') || s.includes('crios') || s.includes('chromium')) return 'Chrome'
+  if (s.includes('safari')) return 'Safari'
+  if (s.includes('curl')) return 'curl'
+  if (s.includes('postman')) return 'Postman'
+  if (/python|node|go-http|okhttp|bun|axios|wget|java\//.test(s)) return 'API client'
+  return 'Other'
+}

--- a/src/views/MapsetListView.vue
+++ b/src/views/MapsetListView.vue
@@ -17,7 +17,8 @@ const columns = [
   { field: 'icon', title: '', width: '3rem' },
   { field: 'name', title: 'Name' },
   { field: 'public', title: 'Visibility', width: '8rem' },
-  { field: 'id', title: 'ID', width: '20rem' },
+  { field: 'layers', title: 'Layers', width: '6rem', align: 'right' as const },
+  { field: 'id', title: 'ID', width: '18rem' },
 ]
 
 const { rows, loading, error, search, record, filteredRows, select: handleSelect } =
@@ -79,6 +80,9 @@ const handleLayersSaved = async function (updated: IMapset) {
         <Badge :variant="row.public ? 'success' : 'default'">
           {{ row.public ? 'Public' : 'Private' }}
         </Badge>
+      </template>
+      <template #layers="{ row }">
+        <span class="font-mono text-xs text-grey-700">{{ row.layers?.length ?? 0 }}</span>
       </template>
       <template #id="{ row }">
         <div class="flex items-center justify-between gap-2">

--- a/src/views/SessionListView.vue
+++ b/src/views/SessionListView.vue
@@ -8,6 +8,7 @@ import Table from '@/components/Common/Table.vue'
 import Alert from '@/components/Common/Alert.vue'
 import Button from '@/components/Common/Buttons/Button.vue'
 import MonoBadge from '@/components/Common/MonoBadge.vue'
+import Input from '@/components/Common/Inputs/Input.vue'
 
 import {
   deleteSession,
@@ -18,6 +19,7 @@ import type { ISession } from '@/services/fundermaps/interfaces/ISession'
 import type { IUser } from '@/services/fundermaps/interfaces/IUser'
 import { renderUserName } from '@/utils/user'
 import { formatDate, formatIpAddress, formatValidFor } from '@/utils/date'
+import { describeClient } from '@/utils/userAgent'
 import { useFlash } from '@/composables/useFlash'
 import { useListResource } from '@/composables/useListResource'
 import { getErrorMessage } from '@/services/fundermaps/errors'
@@ -27,6 +29,7 @@ const router = useRouter()
 
 const actionError = ref<string | null>(null)
 const { message: actionSuccess, flash: flashSuccess } = useFlash()
+const includeExpired = ref(false)
 
 // "now" tick — keep the relative duration ("valid for 14m") fresh without
 // refetching the list. Single shared computed clock for every row.
@@ -41,8 +44,10 @@ const userIdFilter = computed<string | null>(() => {
 
 const columns = [
   { field: 'user_id', title: 'User' },
-  { field: 'valid_for', title: 'Valid for', width: '10rem' },
-  { field: 'created_at', title: 'Created', width: '13rem' },
+  { field: 'client', title: 'Client', width: '7rem' },
+  { field: 'ip_address', title: 'IP address', width: '12rem' },
+  { field: 'valid_for', title: 'Valid for', width: '8rem' },
+  { field: 'created_at', title: 'Created', width: '12rem' },
 ]
 
 const users: Ref<IUser[]> = ref([])
@@ -58,21 +63,39 @@ const filteredUser = computed<IUser | null>(() => {
   return userMap.value.get(userIdFilter.value) ?? null
 })
 
+const renderUserCell = function (userId: string): string {
+  const u = userMap.value.get(userId)
+  if (!u) return userId
+  const name = renderUserName(u)
+  return name ? `${name} <${u.email}>` : u.email
+}
+
 const {
   rows,
   loading,
   error,
+  search,
   record,
+  filteredRows,
   refresh: refreshList,
+  refreshAndSelectFirst,
   select: handleSelect,
   selectFirst: selectFirstRow,
 } = useListResource<ISession>({
   fetch: async () => {
-    const sessions = await getAllSessions({ userId: userIdFilter.value ?? undefined })
+    const sessions = await getAllSessions({
+      userId: userIdFilter.value ?? undefined,
+      includeExpired: includeExpired.value,
+    })
     return sessions.sort(
       (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
     )
   },
+  filter: (s, q) =>
+    renderUserCell(s.user_id).toLowerCase().includes(q) ||
+    (s.ip_address ?? '').toLowerCase().includes(q) ||
+    (s.user_agent ?? '').toLowerCase().includes(q) ||
+    describeClient(s.user_agent).toLowerCase().includes(q),
   onSelect: () => {
     actionError.value = null
     actionSuccess.value = null
@@ -98,10 +121,7 @@ onBeforeMount(async () => {
   }, 60_000)
 })
 
-watch(userIdFilter, async () => {
-  await refreshList()
-  selectFirstRow()
-})
+watch([userIdFilter, includeExpired], () => refreshAndSelectFirst())
 
 onBeforeUnmount(() => {
   if (clockHandle !== null) clearInterval(clockHandle)
@@ -128,13 +148,6 @@ const handleForceLogout = async function () {
     actionError.value = getErrorMessage(e) ?? 'Failed to terminate session.'
   }
 }
-
-const renderUserCell = function (userId: string): string {
-  const u = userMap.value.get(userId)
-  if (!u) return userId
-  const name = renderUserName(u)
-  return name ? `${name} <${u.email}>` : u.email
-}
 </script>
 
 <template>
@@ -158,20 +171,42 @@ const renderUserCell = function (userId: string): string {
       <Button v-if="userIdFilter" outline label="Clear filter" @click="handleClearUserFilter" />
     </header>
 
+    <div class="mb-3 flex items-center gap-4">
+      <div class="w-72">
+        <Input
+          id="session-search"
+          v-model="search"
+          type="search"
+          placeholder="Search by user, IP, client…"
+        />
+      </div>
+      <label class="flex cursor-pointer items-center gap-2 text-sm text-grey-700">
+        <input v-model="includeExpired" type="checkbox" class="h-4 w-4 accent-green-500" />
+        Include expired
+      </label>
+      <span class="text-xs text-grey-700">{{ filteredRows.length }} of {{ rows.length }}</span>
+    </div>
+
     <Alert v-if="error" :closeable="true" class="mb-3" @close="error = false">
       An error occurred while trying to retrieve the list of sessions.
     </Alert>
 
     <Table
-      :rows="rows"
+      :rows="filteredRows"
       :columns="columns"
       :loading="loading"
       :selectedId="record?.id"
-      emptyMessage="No active sessions."
+      emptyMessage="No sessions match your filters."
       @select="handleSelect"
     >
       <template #user_id="{ row }">
         <span class="text-grey-800">{{ renderUserCell(row.user_id) }}</span>
+      </template>
+      <template #client="{ row }">
+        <span class="text-grey-700">{{ describeClient(row.user_agent) }}</span>
+      </template>
+      <template #ip_address="{ row }">
+        <span class="font-mono text-xs text-grey-700">{{ formatIpAddress(row.ip_address) }}</span>
       </template>
       <template #valid_for="{ row }">
         <span class="font-mono text-xs text-grey-700">{{ formatValidFor(row.expires_at, now) }}</span>

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, type Ref } from 'vue'
+import { RouterLink } from 'vue-router'
 
 import Card from '@/components/Common/Card.vue'
 import Button from '@/components/Common/Buttons/Button.vue'
@@ -365,6 +366,18 @@ const handleRoleChange = async function (newRole: string) {
                 <MonoBadge :value="org.id" />
               </div>
             </div>
+          </section>
+
+          <section>
+            <h6 class="mb-2 text-xs font-semibold uppercase tracking-wide text-grey-700">
+              Sessions
+            </h6>
+            <RouterLink
+              :to="{ name: 'sessions', query: { user_id: record.id } }"
+              class="text-sm font-medium text-green-700 hover:text-green-800"
+            >
+              View active sessions →
+            </RouterLink>
           </section>
 
           <section>


### PR DESCRIPTION
Frontend-only quality-of-life batch (uses data/params the API already returns).

## Sessions
- **Search** box (matches user, IP, client, raw user-agent).
- **Client** (browser) and **IP address** columns — were detail-only before. `utils/userAgent.ts` `describeClient()` turns the UA into Chrome/Firefox/Safari/Edge/curl/API client.
- **Include expired** toggle (server-side `include_expired`), so you can see lapsed sessions too.

## Mapsets
- **Layer count** column.

## Users
- **"View active sessions →"** link in the detail panel → the sessions list filtered by that `user_id`.

## Verification
`pnpm build` + `eslint` pass. E2E against the live API: `include_expired` returns 8 → 21 sessions; rows carry `ip_address`/`user_agent`; `describeClient` unit-checked across UA samples. No authenticated SPA click-through (OIDC localhost gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)