### PR TITLE
feat(ui): surface user timestamps — detail + recent signups

### DIFF
--- a/src/services/fundermaps/interfaces/IUser.ts
+++ b/src/services/fundermaps/interfaces/IUser.ts
@@ -9,5 +9,7 @@ export interface IUser {
   job_title: string | null
   phone_number: string | null
   role: string
+  created_at?: string | null
+  updated_at?: string | null
   organizations: IOrganization[] | null
 }

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -16,12 +16,15 @@ import {
   JOBS_LIST_LIMIT,
 } from '@/services/fundermaps/endpoints/management/job'
 import type { IJob, JobStatus } from '@/services/fundermaps/interfaces/IJob'
+import type { IUser } from '@/services/fundermaps/interfaces/IUser'
 import { formatDate } from '@/utils/date'
+import { renderUserName } from '@/utils/user'
 
 const loading = ref(true)
 const error = ref(false)
 
 const userCount = ref(0)
+const usersList = ref<IUser[]>([])
 const orgCount = ref(0)
 const mapsetCount = ref(0)
 const sessionCount = ref(0)
@@ -42,6 +45,7 @@ const refresh = async function () {
       getAllJobs(),
     ])
     userCount.value = users.length
+    usersList.value = users
     atUserCap.value = users.length >= USERS_LIST_LIMIT
     orgCount.value = orgs.length
     mapsetCount.value = mapsets.length
@@ -77,6 +81,13 @@ const jobCounts = computed<Record<JobStatus, number>>(() => {
 const unhealthyJobs = computed(() => jobCounts.value.failed + jobCounts.value.retry)
 
 const recentJobs = computed(() => jobs.value.slice(0, 6))
+
+const recentUsers = computed(() =>
+  [...usersList.value]
+    .filter((u) => u.created_at)
+    .sort((a, b) => new Date(b.created_at!).getTime() - new Date(a.created_at!).getTime())
+    .slice(0, 6),
+)
 
 const statusVariant = (status: JobStatus): 'success' | 'info' | 'danger' | 'warning' | 'default' => {
   switch (status) {
@@ -116,31 +127,31 @@ const statusVariant = (status: JobStatus): 'success' | 'info' | 'danger' | 'warn
       </RouterLink>
     </div>
 
-    <div class="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <Card title="Job queue">
-        <Alert v-if="!loading && unhealthyJobs > 0" type="warning" class="mb-3">
-          {{ jobCounts.failed }} failed and {{ jobCounts.retry }} retrying in the last
-          {{ jobs.length }} jobs.
-        </Alert>
-        <div class="flex flex-wrap gap-x-6 gap-y-2">
-          <div v-for="status in STATUS_ORDER" :key="status" class="flex items-center gap-2 text-sm">
-            <Badge :variant="statusVariant(status)">{{ status }}</Badge>
-            <span class="font-mono text-grey-800">{{ loading ? '…' : jobCounts[status] }}</span>
-          </div>
+    <Card title="Job queue" class="mt-6">
+      <Alert v-if="!loading && unhealthyJobs > 0" type="warning" class="mb-3">
+        {{ jobCounts.failed }} failed and {{ jobCounts.retry }} retrying in the last
+        {{ jobs.length }} jobs.
+      </Alert>
+      <div class="flex flex-wrap gap-x-6 gap-y-2">
+        <div v-for="status in STATUS_ORDER" :key="status" class="flex items-center gap-2 text-sm">
+          <Badge :variant="statusVariant(status)">{{ status }}</Badge>
+          <span class="font-mono text-grey-800">{{ loading ? '…' : jobCounts[status] }}</span>
         </div>
-        <p v-if="atJobCap" class="mt-3 text-xs text-grey-700">
-          Counts cover the most recent {{ JOBS_LIST_LIMIT }} jobs.
-        </p>
-        <template #footer>
-          <RouterLink
-            :to="{ name: 'jobs' }"
-            class="text-sm font-medium text-green-700 hover:text-green-800"
-          >
-            View all jobs →
-          </RouterLink>
-        </template>
-      </Card>
+      </div>
+      <p v-if="atJobCap" class="mt-3 text-xs text-grey-700">
+        Counts cover the most recent {{ JOBS_LIST_LIMIT }} jobs.
+      </p>
+      <template #footer>
+        <RouterLink
+          :to="{ name: 'jobs' }"
+          class="text-sm font-medium text-green-700 hover:text-green-800"
+        >
+          View all jobs →
+        </RouterLink>
+      </template>
+    </Card>
 
+    <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
       <Card title="Recent jobs">
         <div v-if="loading" class="text-sm text-grey-700">Loading…</div>
         <div v-else-if="!recentJobs.length" class="text-sm text-grey-700">No jobs yet.</div>
@@ -156,6 +167,25 @@ const statusVariant = (status: JobStatus): 'success' | 'info' | 'danger' | 'warn
             </div>
             <Badge :variant="statusVariant(job.status)">{{ job.status }}</Badge>
             <span class="shrink-0 text-xs text-grey-700">{{ formatDate(job.created_at) }}</span>
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Recent signups">
+        <div v-if="loading" class="text-sm text-grey-700">Loading…</div>
+        <div v-else-if="!recentUsers.length" class="text-sm text-grey-700">
+          No recent signups.
+        </div>
+        <div v-else class="overflow-hidden rounded-md border border-grey-200">
+          <div
+            v-for="user in recentUsers"
+            :key="user.id"
+            class="flex items-center justify-between gap-3 border-b border-grey-200 px-3 py-2 text-sm last:border-b-0"
+          >
+            <span class="min-w-0 flex-1 truncate font-medium text-grey-800">
+              {{ renderUserName(user) || user.email }}
+            </span>
+            <span class="shrink-0 text-xs text-grey-700">{{ formatDate(user.created_at ?? null) }}</span>
           </div>
         </div>
       </Card>

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -29,6 +29,7 @@ import {
 } from '@/services/fundermaps/endpoints/management/user.ts'
 import type { IUser } from '@/services/fundermaps/interfaces/IUser.ts'
 import { getInitials, renderUserName } from '@/utils/user'
+import { formatDate } from '@/utils/date'
 import { useFlash } from '@/composables/useFlash'
 import { useListResource } from '@/composables/useListResource'
 import { getErrorMessage } from '@/services/fundermaps/errors'
@@ -344,6 +345,10 @@ const handleRoleChange = async function (newRole: string) {
             <dd class="text-grey-800">{{ record.phone_number || '—' }}</dd>
             <dt class="text-grey-700">Job title</dt>
             <dd class="text-grey-800">{{ record.job_title || '—' }}</dd>
+            <dt class="text-grey-700">Created</dt>
+            <dd class="text-grey-800">{{ formatDate(record.created_at ?? null) }}</dd>
+            <dt class="text-grey-700">Updated</dt>
+            <dd class="text-grey-800">{{ formatDate(record.updated_at ?? null) }}</dd>
           </dl>
 
           <section>


### PR DESCRIPTION
Surfaces the user `created_at`/`updated_at` now returned by the API (**FunderMapsApi#66**).

- **`IUser`** gains optional `created_at` / `updated_at`.
- **User detail** panel shows **Created** and **Updated** rows.
- **Dashboard** gains a **"Recent signups"** card (latest users by `created_at`). Job queue moves full-width above a Recent jobs / Recent signups row.

Depends on #66 for the data; the fields are optional and every consumer is empty-state-guarded, so this is safe to merge/deploy independently (signups card just shows "No recent signups" until #66 ships).

## Verification
`pnpm build` + `eslint` pass. The API side was E2E-verified in #66 (getUser/list return the ISO timestamps). No authenticated SPA click-through (OIDC localhost gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)