### PR TITLE
feat(ui): loading skeletons + button loading states

### DIFF
--- a/src/components/Common/Buttons/Button.vue
+++ b/src/components/Common/Buttons/Button.vue
@@ -7,9 +7,10 @@ import { computed } from 'vue'
  * Sizes: default (compact) or lg (page-level primary actions).
  */
 
-const { link, ghost, outline, muted, danger, lg } = defineProps({
+const { link, ghost, outline, muted, danger, lg, loading } = defineProps({
   label: { type: String, default: 'Button' },
   disabled: { type: Boolean, default: false },
+  loading: { type: Boolean, default: false },
   link: { type: Boolean, default: false },
   ghost: { type: Boolean, default: false },
   outline: { type: Boolean, default: false },
@@ -40,8 +41,9 @@ const btnClass = computed<string[]>(() => {
 </script>
 
 <template>
-  <button class="button" :class="btnClass" :disabled="disabled">
-    <slot name="before" />
+  <button class="button" :class="btnClass" :disabled="disabled || loading">
+    <span v-if="loading" class="button__spinner" aria-hidden="true" />
+    <slot v-else name="before" />
     <span class="button__label">{{ label }}</span>
     <slot name="after" />
   </button>

--- a/src/components/Common/Skeleton.vue
+++ b/src/components/Common/Skeleton.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    width?: string
+    height?: string
+    rounded?: string
+  }>(),
+  {
+    width: '100%',
+    height: '0.85rem',
+    rounded: 'rounded',
+  },
+)
+</script>
+
+<template>
+  <span
+    class="block animate-pulse bg-grey-200"
+    :class="rounded"
+    :style="{ width, height }"
+    aria-hidden="true"
+  />
+</template>

--- a/src/components/Common/Table.vue
+++ b/src/components/Common/Table.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts" generic="T">
+import Skeleton from '@/components/Common/Skeleton.vue'
+
 type Column = {
   field: string
   title: string
@@ -44,6 +46,10 @@ const isSelected = (row: T): boolean => {
   if (props.selectedId == null) return false
   return fieldValue(row, 'id') === props.selectedId
 }
+
+// A natural-looking skeleton bar width per column: narrow for numeric/aligned
+// columns, wider for the main text columns.
+const skeletonWidth = (c: Column): string => (c.align === 'right' || c.width ? '45%' : '75%')
 </script>
 
 <template>
@@ -65,11 +71,13 @@ const isSelected = (row: T): boolean => {
         </tr>
       </thead>
       <tbody>
-        <tr v-if="loading">
-          <td :colspan="columns.length" class="px-3 py-4 text-center text-grey-700">
-            {{ loadingMessage }}
-          </td>
-        </tr>
+        <template v-if="loading">
+          <tr v-for="n in 6" :key="`skeleton-${n}`" class="border-t border-grey-200">
+            <td v-for="c in columns" :key="c.field" class="px-3 py-2.5">
+              <Skeleton :width="skeletonWidth(c)" />
+            </td>
+          </tr>
+        </template>
         <tr v-else-if="!rows.length">
           <td :colspan="columns.length" class="px-3 py-4 text-center text-grey-700">
             {{ emptyMessage }}

--- a/src/components/Management/Form.vue
+++ b/src/components/Management/Form.vue
@@ -120,7 +120,7 @@ const handleReset = function handleReset() {
 
       <div :class="inline ? 'ml-2 flex justify-end pt-7' : 'mt-6 flex justify-end space-x-3'">
         <Button v-if="!inline" type="button" label="Cancel" outline @click="handleReset" />
-        <Button type="submit" label="Submit" :disabled="loading">
+        <Button type="submit" label="Submit" :loading="loading">
           <template v-slot:after>
             <AnimatedArrowIcon />
           </template>

--- a/src/styles/components/button.css
+++ b/src/styles/components/button.css
@@ -6,6 +6,10 @@
   @apply gap-2 rounded-md px-5 py-3 text-base;
 }
 
+.button__spinner {
+  @apply inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent;
+}
+
 .button--solid {
   @apply bg-green-500 text-white hover:bg-green-700 disabled:bg-grey-400;
 }

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -6,6 +6,7 @@ import MainWrapper from '@/components/Layout/MainWrapper.vue'
 import Card from '@/components/Common/Card.vue'
 import Alert from '@/components/Common/Alert.vue'
 import Badge from '@/components/Common/Badge.vue'
+import Skeleton from '@/components/Common/Skeleton.vue'
 
 import { getAllUsers, USERS_LIST_LIMIT } from '@/services/fundermaps/endpoints/management/user'
 import { getAllOrganisations } from '@/services/fundermaps/endpoints/management/organisation'
@@ -122,7 +123,8 @@ const statusVariant = (status: JobStatus): 'success' | 'info' | 'danger' | 'warn
           <div class="text-xs font-semibold uppercase tracking-wide text-grey-700">
             {{ s.label }}
           </div>
-          <div class="mt-1 text-3xl font-semibold text-grey-800">{{ s.value }}</div>
+          <Skeleton v-if="loading" class="mt-2" width="3rem" height="1.75rem" />
+          <div v-else class="mt-1 text-3xl font-semibold text-grey-800">{{ s.value }}</div>
         </Card>
       </RouterLink>
     </div>
@@ -153,7 +155,9 @@ const statusVariant = (status: JobStatus): 'success' | 'info' | 'danger' | 'warn
 
     <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
       <Card title="Recent jobs">
-        <div v-if="loading" class="text-sm text-grey-700">Loading…</div>
+        <div v-if="loading" class="space-y-2.5 py-1">
+          <Skeleton v-for="n in 5" :key="`skj-${n}`" />
+        </div>
         <div v-else-if="!recentJobs.length" class="text-sm text-grey-700">No jobs yet.</div>
         <div v-else class="overflow-hidden rounded-md border border-grey-200">
           <div
@@ -172,7 +176,9 @@ const statusVariant = (status: JobStatus): 'success' | 'info' | 'danger' | 'warn
       </Card>
 
       <Card title="Recent signups">
-        <div v-if="loading" class="text-sm text-grey-700">Loading…</div>
+        <div v-if="loading" class="space-y-2.5 py-1">
+          <Skeleton v-for="n in 5" :key="`sku-${n}`" />
+        </div>
         <div v-else-if="!recentUsers.length" class="text-sm text-grey-700">
           No recent signups.
         </div>

--- a/src/views/JobListView.vue
+++ b/src/views/JobListView.vue
@@ -23,6 +23,7 @@ import { useFlash } from '@/composables/useFlash'
 import { getErrorMessage } from '@/services/fundermaps/errors'
 
 const statusFilter = ref('')
+const cancelling = ref(false)
 const actionError = ref<string | null>(null)
 const { message: actionSuccess, flash: flashSuccess } = useFlash()
 
@@ -122,12 +123,15 @@ const handleCancel = async function () {
   if (!confirm(`Cancel job #${record.value.id}? It will be marked as failed.`)) return
 
   try {
+    cancelling.value = true
     actionError.value = null
     record.value = await cancelJob(record.value.id)
     await refresh()
     flashSuccess('Job cancelled.')
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to cancel job.'
+  } finally {
+    cancelling.value = false
   }
 }
 </script>
@@ -204,7 +208,7 @@ const handleCancel = async function () {
       <Drawer>
         <template #title>Job information</template>
         <template v-if="record && canCancel(record)" #actions>
-          <Button danger label="Cancel job" @click="handleCancel" />
+          <Button danger label="Cancel job" :loading="cancelling" @click="handleCancel" />
         </template>
 
         <template v-if="record">

--- a/src/views/OrganisationListView.vue
+++ b/src/views/OrganisationListView.vue
@@ -30,6 +30,7 @@ import PlusIcon from '@assets/svg/icons/plus.svg?component'
 
 const showCreate = ref(false)
 const showEdit = ref(false)
+const deleting = ref(false)
 const actionError = ref<string | null>(null)
 
 const activeTab: Ref<'users' | 'mapsets' | 'geolock'> = ref('users')
@@ -91,6 +92,7 @@ const handleDelete = async function () {
   if (!confirm(`Delete organisation "${record.value.name}"? This cannot be undone.`)) return
 
   try {
+    deleting.value = true
     actionError.value = null
     await deleteOrganisation(record.value.id)
     record.value = null
@@ -99,6 +101,8 @@ const handleDelete = async function () {
     selectFirstRow()
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to delete organisation.'
+  } finally {
+    deleting.value = false
   }
 }
 </script>
@@ -163,8 +167,8 @@ const handleDelete = async function () {
         </template>
 
         <template v-if="drawerMode === 'details'" #actions>
-          <Button outline label="Edit" @click="handleEdit" />
-          <Button danger label="Delete" @click="handleDelete" />
+          <Button outline label="Edit" :disabled="deleting" @click="handleEdit" />
+          <Button danger label="Delete" :loading="deleting" @click="handleDelete" />
         </template>
 
         <CreateOrganisationForm

--- a/src/views/SessionListView.vue
+++ b/src/views/SessionListView.vue
@@ -30,6 +30,7 @@ const router = useRouter()
 const actionError = ref<string | null>(null)
 const { message: actionSuccess, flash: flashSuccess } = useFlash()
 const includeExpired = ref(false)
+const terminating = ref(false)
 
 // "now" tick — keep the relative duration ("valid for 14m") fresh without
 // refetching the list. Single shared computed clock for every row.
@@ -138,6 +139,7 @@ const handleForceLogout = async function () {
   if (!confirm(`Terminate session for "${label}"? They will need to sign in again.`)) return
 
   try {
+    terminating.value = true
     actionError.value = null
     await deleteSession(record.value.id)
     record.value = null
@@ -146,6 +148,8 @@ const handleForceLogout = async function () {
     flashSuccess('Session terminated.')
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to terminate session.'
+  } finally {
+    terminating.value = false
   }
 }
 </script>
@@ -218,7 +222,7 @@ const handleForceLogout = async function () {
       <Drawer>
         <template #title>Session information</template>
         <template v-if="record" #actions>
-          <Button danger label="Terminate" @click="handleForceLogout" />
+          <Button danger label="Terminate" :loading="terminating" @click="handleForceLogout" />
         </template>
 
         <template v-if="record">

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -13,6 +13,7 @@ import Alert from '@/components/Common/Alert.vue'
 import Badge from '@/components/Common/Badge.vue'
 import MonoBadge from '@/components/Common/MonoBadge.vue'
 import ListRow from '@/components/Common/ListRow.vue'
+import Skeleton from '@/components/Common/Skeleton.vue'
 import Input from '@/components/Common/Inputs/Input.vue'
 import Select from '@/components/Common/Inputs/Select.vue'
 import PlusIcon from '@assets/svg/icons/plus.svg?component'
@@ -41,6 +42,8 @@ const showEdit = ref(false)
 const actionError = ref<string | null>(null)
 const { message: actionSuccess, flash: flashSuccess } = useFlash()
 const newApiKey = ref<string | null>(null)
+const deleting = ref(false)
+const generatingKey = ref(false)
 const createdUser = ref<{
   email: string
   password: string
@@ -139,12 +142,15 @@ const handleCreateAPIKey = async function () {
   if (!confirm('Generate a new API key for this user?')) return
 
   try {
+    generatingKey.value = true
     actionError.value = null
     const response = await createAPIKey(record.value.id)
     apiKeys.value = await getAPIKeys(record.value.id)
     newApiKey.value = response.key
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to generate API key.'
+  } finally {
+    generatingKey.value = false
   }
 }
 
@@ -167,6 +173,7 @@ const handleDelete = async function () {
   if (!confirm(`Delete user "${record.value.email}"? This cannot be undone.`)) return
 
   try {
+    deleting.value = true
     actionError.value = null
     await deleteUser(record.value.id)
     record.value = null
@@ -175,6 +182,8 @@ const handleDelete = async function () {
     selectFirstRow()
   } catch (e) {
     actionError.value = getErrorMessage(e) ?? 'Failed to delete user.'
+  } finally {
+    deleting.value = false
   }
 }
 
@@ -226,7 +235,19 @@ const handleRoleChange = async function (newRole: string) {
     </Alert>
 
     <Card class="!p-0">
-      <div v-if="loading" class="px-4 py-6 text-sm text-grey-700">Loading users…</div>
+      <template v-if="loading">
+        <div
+          v-for="n in 6"
+          :key="`skeleton-${n}`"
+          class="flex items-center gap-4 border-b border-grey-200 px-4 py-3 last:border-b-0"
+        >
+          <Skeleton width="2.25rem" height="2.25rem" rounded="rounded-md" />
+          <div class="flex flex-1 flex-col gap-1.5">
+            <Skeleton width="40%" />
+            <Skeleton width="60%" height="0.7rem" />
+          </div>
+        </div>
+      </template>
       <div v-else-if="!filteredRows.length" class="px-4 py-6 text-sm text-grey-700">
         No users match your search.
       </div>
@@ -271,8 +292,8 @@ const handleRoleChange = async function (newRole: string) {
         </template>
 
         <template v-if="drawerMode === 'details'" #actions>
-          <Button outline label="Edit" @click="handleEdit" />
-          <Button danger label="Delete" @click="handleDelete" />
+          <Button outline label="Edit" :disabled="deleting" @click="handleEdit" />
+          <Button danger label="Delete" :loading="deleting" @click="handleDelete" />
         </template>
 
         <!-- Create -->
@@ -410,7 +431,7 @@ const handleRoleChange = async function (newRole: string) {
               <h6 class="text-xs font-semibold uppercase tracking-wide text-grey-700">
                 API keys
               </h6>
-              <Button outline label="Generate" @click="handleCreateAPIKey" />
+              <Button outline label="Generate" :loading="generatingKey" @click="handleCreateAPIKey" />
             </div>
             <Alert
               v-if="newApiKey"


### PR DESCRIPTION
Perceived-speed and feedback polish.

## Skeletons
- New `Skeleton` component (pulsing bar).
- **Table** shows skeleton rows while loading instead of a centered "Loading…" row — no text-flash, no layout jump (used by Orgs/Mapsets/Jobs/Sessions).
- **User list** shows avatar + two-line skeletons.
- **Dashboard** skeletons its stat numbers and the recent-jobs / recent-signups lists.

## Button loading states
- `Button` gains a `loading` prop → disables + shows a spinner (CSS, inherits text colour).
- Applied to every mutating action: **delete user/org, cancel job, terminate session, generate API key**, and the generic **form Submit** button (was disable-only). Kills double-clicks and "did it work?" moments.

## Verification
`pnpm build` + `eslint` pass; rendered the skeleton + spinner states via headless Chromium. No authenticated SPA click-through (OIDC localhost gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)