### PR TITLE
feat(ui): deep-linkable selection (selected record in the URL)

### DIFF
--- a/src/composables/useListResource.ts
+++ b/src/composables/useListResource.ts
@@ -1,4 +1,4 @@
-import { computed, onBeforeMount, ref, type ComputedRef, type Ref } from 'vue'
+import { computed, onBeforeMount, ref, watch, type ComputedRef, type Ref } from 'vue'
 
 export interface UseListResourceOptions<T> {
   /** Fetch the full list of rows. */
@@ -13,6 +13,12 @@ export interface UseListResourceOptions<T> {
   autoSelectFirst?: boolean
   /** Fetch on mount (default true). Set false to drive initialisation manually. */
   immediate?: boolean
+  /** Row identity used for URL sync + matching (default: `row.id`). */
+  key?: (row: T) => string | number
+  /** Current selected id read from the route, for deep-linkable selection. */
+  routeId?: () => string | undefined
+  /** Write the selected id back to the route (called with the row's key). */
+  syncRoute?: (id: string) => void
 }
 
 export interface UseListResource<T> {
@@ -24,6 +30,7 @@ export interface UseListResource<T> {
   filteredRows: ComputedRef<T[]>
   refresh: () => Promise<void>
   select: (row: T) => Promise<void>
+  selectById: (id: string) => void
   selectFirst: () => void
   refreshAndSelectFirst: () => Promise<void>
 }
@@ -33,7 +40,7 @@ export interface UseListResource<T> {
  * state, a search-filtered view of it, and a selected `record` shown in the
  * docked detail panel. The first row is selected on load so the panel is never
  * empty. View-specific behaviour hangs off the `filter`, `resolve` and
- * `onSelect` hooks.
+ * `onSelect` hooks; pass `routeId`/`syncRoute` to keep the selection in the URL.
  */
 export function useListResource<T>(options: UseListResourceOptions<T>): UseListResource<T> {
   const rows = ref([]) as Ref<T[]>
@@ -41,6 +48,9 @@ export function useListResource<T>(options: UseListResourceOptions<T>): UseListR
   const error = ref(false)
   const search = ref('')
   const record = ref(null) as Ref<T | null>
+
+  const keyOf = (row: T): string =>
+    String(options.key ? options.key(row) : (row as Record<string, unknown>).id)
 
   const filteredRows = computed<T[]>(() => {
     const query = search.value.trim().toLowerCase()
@@ -60,10 +70,18 @@ export function useListResource<T>(options: UseListResourceOptions<T>): UseListR
     }
   }
 
-  async function select(row: T) {
+  // syncRoute=false when the selection originates from the route itself
+  // (initial load / back-forward), to avoid a navigation loop.
+  async function select(row: T, syncRoute = true) {
     options.onSelect?.(row, record.value)
     record.value = row
     if (options.resolve) record.value = await options.resolve(row)
+    if (syncRoute) options.syncRoute?.(keyOf(row))
+  }
+
+  function selectById(id: string) {
+    const row = rows.value.find((r) => keyOf(r) === id)
+    if (row) select(row, false)
   }
 
   function selectFirst() {
@@ -73,7 +91,19 @@ export function useListResource<T>(options: UseListResourceOptions<T>): UseListR
 
   async function refreshAndSelectFirst() {
     await refresh()
-    if (options.autoSelectFirst !== false) selectFirst()
+    if (options.autoSelectFirst === false) return
+    const id = options.routeId?.()
+    if (id && rows.value.some((r) => keyOf(r) === id)) selectById(id)
+    else selectFirst()
+  }
+
+  // React to external route changes (back/forward, shared links) within the
+  // same view. Skip when the route already matches what we just selected.
+  if (options.routeId) {
+    watch(options.routeId, (id) => {
+      if (!id || (record.value && keyOf(record.value) === id)) return
+      selectById(id)
+    })
   }
 
   if (options.immediate !== false) {
@@ -89,6 +119,7 @@ export function useListResource<T>(options: UseListResourceOptions<T>): UseListR
     filteredRows,
     refresh,
     select,
+    selectById,
     selectFirst,
     refreshAndSelectFirst,
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -61,31 +61,31 @@ const router = createRouter({
     },
     {
       name: 'organisations',
-      path: '/organisation',
+      path: '/organisation/:id?',
       component: OrganisationListView,
     },
 
     {
       name: 'mapsets',
-      path: '/mapset',
+      path: '/mapset/:id?',
       component: MapsetListView,
     },
 
     {
       name: 'users',
-      path: '/user',
+      path: '/user/:id?',
       component: UserListView,
     },
 
     {
       name: 'jobs',
-      path: '/job',
+      path: '/job/:id?',
       component: JobListView,
     },
 
     {
       name: 'sessions',
-      path: '/session',
+      path: '/session/:id?',
       component: SessionListView,
     },
   ],

--- a/src/views/JobListView.vue
+++ b/src/views/JobListView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
 import MainWrapper from '@/components/Layout/MainWrapper.vue'
 import Drawer from '@/components/Layout/Drawer.vue'
@@ -21,6 +22,9 @@ import { formatDate, formatDuration } from '@/utils/date'
 import { useListResource } from '@/composables/useListResource'
 import { useFlash } from '@/composables/useFlash'
 import { getErrorMessage } from '@/services/fundermaps/errors'
+
+const route = useRoute()
+const router = useRouter()
 
 const statusFilter = ref('')
 const actionError = ref<string | null>(null)
@@ -70,6 +74,9 @@ const {
         return row
       }
     },
+    key: (j) => j.id,
+    routeId: () => (typeof route.params.id === 'string' ? route.params.id : undefined),
+    syncRoute: (id) => router.replace({ name: 'jobs', params: { id }, query: route.query }),
   })
 
 // Re-fetch from the server when the status filter changes, landing on the

--- a/src/views/MapsetListView.vue
+++ b/src/views/MapsetListView.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+
 import MainWrapper from '@/components/Layout/MainWrapper.vue'
 import Drawer from '@/components/Layout/Drawer.vue'
 import Table from '@/components/Common/Table.vue'
@@ -21,6 +23,9 @@ const columns = [
   { field: 'id', title: 'ID', width: '18rem' },
 ]
 
+const route = useRoute()
+const router = useRouter()
+
 const { rows, loading, error, search, record, filteredRows, select: handleSelect } =
   useListResource<IMapset>({
     fetch: getAllMapsets,
@@ -28,6 +33,8 @@ const { rows, loading, error, search, record, filteredRows, select: handleSelect
       m.name.toLowerCase().includes(q) ||
       (m.slug ?? '').toLowerCase().includes(q) ||
       m.id.toLowerCase().includes(q),
+    routeId: () => (typeof route.params.id === 'string' ? route.params.id : undefined),
+    syncRoute: (id) => router.replace({ name: 'mapsets', params: { id }, query: route.query }),
   })
 
 const handleLayersSaved = async function (updated: IMapset) {

--- a/src/views/OrganisationListView.vue
+++ b/src/views/OrganisationListView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, type Ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
 import Button from '@/components/Common/Buttons/Button.vue'
 import MainWrapper from '@/components/Layout/MainWrapper.vue'
@@ -41,6 +42,9 @@ const columns = [
   { field: 'id', title: 'ID', width: '20rem' },
 ]
 
+const route = useRoute()
+const router = useRouter()
+
 const {
   rows,
   loading,
@@ -60,6 +64,8 @@ const {
     actionError.value = null
     if (previous?.id !== row.id) activeTab.value = 'users'
   },
+  routeId: () => (typeof route.params.id === 'string' ? route.params.id : undefined),
+  syncRoute: (id) => router.replace({ name: 'organisations', params: { id }, query: route.query }),
 })
 
 const drawerMode = computed<'create' | 'edit' | 'details' | null>(() => {

--- a/src/views/SessionListView.vue
+++ b/src/views/SessionListView.vue
@@ -80,6 +80,7 @@ const {
   refresh: refreshList,
   refreshAndSelectFirst,
   select: handleSelect,
+  selectById,
   selectFirst: selectFirstRow,
 } = useListResource<ISession>({
   fetch: async () => {
@@ -100,6 +101,8 @@ const {
     actionError.value = null
     actionSuccess.value = null
   },
+  routeId: () => (typeof route.params.id === 'string' ? route.params.id : undefined),
+  syncRoute: (id) => router.replace({ name: 'sessions', params: { id }, query: route.query }),
   immediate: false,
 })
 
@@ -113,7 +116,9 @@ const loadUsers = async function () {
 
 onBeforeMount(async () => {
   await Promise.all([refreshList(), loadUsers()])
-  selectFirstRow()
+  const id = typeof route.params.id === 'string' ? route.params.id : undefined
+  if (id && rows.value.some((s) => s.id === id)) selectById(id)
+  else selectFirstRow()
   // Tick once a minute — sessions are minute-grained; second-resolution
   // would re-render the whole table for no real benefit.
   clockHandle = setInterval(() => {

--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, type Ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 
 import Card from '@/components/Common/Card.vue'
 import Button from '@/components/Common/Buttons/Button.vue'
@@ -57,6 +57,9 @@ interface IAuthKey {
 
 const apiKeys: Ref<IAuthKey[]> = ref([])
 
+const route = useRoute()
+const router = useRouter()
+
 const {
   rows,
   loading,
@@ -92,6 +95,8 @@ const {
     apiKeys.value = keys
     return user
   },
+  routeId: () => (typeof route.params.id === 'string' ? route.params.id : undefined),
+  syncRoute: (id) => router.replace({ name: 'users', params: { id }, query: route.query }),
 })
 
 const drawerMode = computed<'create' | 'created' | 'edit' | 'details' | null>(() => {


### PR DESCRIPTION
Makes the selected record part of the URL, so **refresh keeps your place** and selections are **shareable**.

## How
- List routes gain an optional id segment: `/user/:id?`, `/organisation/:id?`, `/mapset/:id?`, `/job/:id?`, `/session/:id?`.
- `useListResource` gains `key` / `routeId` / `syncRoute` options and a `selectById()`:
  - selecting a row `router.replace()`s its id into the URL;
  - on load / refresh / shared link, the row matching the URL id is selected (falling back to first row otherwise).
- Uses **replace**, not push, so clicking through rows doesn't spam browser history.
- **Loop-guarded**: route-originated selection skips the push, and the `routeId` watch no-ops when the URL already matches the current selection. Job polling uses `refresh()` only, so it never churns the URL.

## Verification
`pnpm build` (type-check + bundle) + `eslint` pass. Behavioural (no visual change); I traced the load / deep-link / click / poll / delete paths for loop-safety. ⚠️ Could **not** click-test live navigation (the SPA's OIDC login needs a localhost redirect the auth server rejects), so the nav flows warrant an eyeball after merge.

## Note
Overlaps PR #44 (skeletons/button-loading) in the view files — whichever merges second needs a trivial rebase; happy to handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
