### PR TITLE
feat: separate user drawer sections with dividers

### DIFF
--- a/src/views/UserListView.vue
+++ b/src/views/UserListView.vue
@@ -377,7 +377,7 @@ const handleRoleChange = async function (newRole: string) {
             <dd class="text-grey-800">{{ formatDate(record.updated_at ?? null) }}</dd>
           </dl>
 
-          <section>
+          <section class="border-t border-grey-200 pt-5">
             <h6 class="mb-2 text-xs font-semibold uppercase tracking-wide text-grey-700">
               Organisations
             </h6>
@@ -399,7 +399,7 @@ const handleRoleChange = async function (newRole: string) {
             </div>
           </section>
 
-          <section>
+          <section class="border-t border-grey-200 pt-5">
             <h6 class="mb-2 text-xs font-semibold uppercase tracking-wide text-grey-700">
               Sessions
             </h6>
@@ -411,7 +411,7 @@ const handleRoleChange = async function (newRole: string) {
             </RouterLink>
           </section>
 
-          <section>
+          <section class="border-t border-grey-200 pt-5">
             <h6 class="mb-2 text-xs font-semibold uppercase tracking-wide text-grey-700">Role</h6>
             <Select
               id="role"
@@ -424,14 +424,14 @@ const handleRoleChange = async function (newRole: string) {
             />
           </section>
 
-          <section>
+          <section class="border-t border-grey-200 pt-5">
             <h6 class="mb-2 text-xs font-semibold uppercase tracking-wide text-grey-700">
               Password
             </h6>
             <UserResetPassword :record="record" />
           </section>
 
-          <section>
+          <section class="border-t border-grey-200 pt-5">
             <div class="mb-2 flex items-center justify-between">
               <h6 class="text-xs font-semibold uppercase tracking-wide text-grey-700">
                 API keys


### PR DESCRIPTION
On the Users page, the right-hand detail drawer stacked **Organisations**, **Sessions**, **Role**, **Password** and **API keys** with only whitespace between them, so the distinct areas blurred together.

This adds a top border + padding to each section so they read as clearly separated blocks, divided from the identity summary at the top.

## Change

- `src/views/UserListView.vue` — each `<section>` in the user details drawer gets `border-t border-grey-200 pt-5`. No logic changes, no new components.

## Verification

- `pnpm type-check` clean; `pnpm build` green.
- Rendered the details drawer in isolation (faithful copy with fake data) and screenshotted it to confirm the dividers + spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)