### PR TITLE
feat: rate limit management screen

### DIFF
--- a/src/components/Layout/Sidebar.vue
+++ b/src/components/Layout/Sidebar.vue
@@ -12,6 +12,7 @@ import SessionsIcon from '@assets/svg/icons/sessions.svg?component'
 import OrganisationsIcon from '@assets/svg/icons/organisations.svg?component'
 import MapsetsIcon from '@assets/svg/icons/mapsets.svg?component'
 import JobsIcon from '@assets/svg/icons/jobs.svg?component'
+import RateLimitsIcon from '@assets/svg/icons/switch.svg?component'
 
 interface NavItem {
   name: string
@@ -41,6 +42,7 @@ const navGroups: NavGroup[] = [
     items: [
       { name: 'mapsets', label: 'Mapsets', icon: MapsetsIcon },
       { name: 'jobs', label: 'Jobs', icon: JobsIcon },
+      { name: 'rate-limits', label: 'Rate limits', icon: RateLimitsIcon },
     ],
   },
 ]

--- a/src/components/Management/Forms/RateLimitForm.vue
+++ b/src/components/Management/Forms/RateLimitForm.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { z } from 'zod'
+
+import Input from '@/components/Common/Inputs/Input.vue'
+import Select from '@/components/Common/Inputs/Select.vue'
+import FormCard from '@/components/Management/FormCard.vue'
+
+import {
+  RATE_LIMIT_PERIODS,
+  RATE_LIMIT_PRODUCTS,
+  upsertRateLimit,
+} from '@/services/fundermaps/endpoints/management/rate-limit'
+import type {
+  IRateLimit,
+  IRateLimitKey,
+  RateLimitPeriod,
+  RateLimitSource,
+} from '@/services/fundermaps/interfaces/IRateLimit'
+
+// Handles both create (pick a key + product) and edit (key + product locked,
+// only period + limit change — they're the table's primary key). Upsert is
+// idempotent server-side, so a single endpoint covers both.
+const props = defineProps<{
+  keys: IRateLimitKey[]
+  record?: IRateLimit | null
+}>()
+const emit = defineEmits(['saved', 'cancel'])
+
+const isEdit = computed(() => !!props.record)
+
+const keyOptions = computed(() =>
+  props.keys.map((k) => ({
+    value: `${k.source}:${k.api_key_id}`,
+    label: `${k.organization_name ?? 'No organisation'} — ${k.name ?? k.api_key_id} (${k.source})`,
+  })),
+)
+
+const productOptions = RATE_LIMIT_PRODUCTS.map((p) => ({ value: p, label: p }))
+const periodOptions = RATE_LIMIT_PERIODS.map((p) => ({
+  value: p,
+  label: p === 'day' ? 'Per day' : 'Per month',
+}))
+
+const formModel = ref({
+  // `source:api_key_id` so a single select round-trips both fields.
+  keyRef: props.record ? `${props.record.source}:${props.record.api_key_id}` : '',
+  product: props.record?.product ?? RATE_LIMIT_PRODUCTS[0],
+  period: (props.record?.period ?? 'month') as RateLimitPeriod,
+  limit_count: props.record?.limit_count ?? 1000,
+})
+
+const validationSchema = z
+  .object({
+    keyRef: z.string().min(1, 'Select an API key.'),
+    product: z.string().min(1, 'Select a product.'),
+    period: z.string().min(1, 'Select a period.'),
+    limit_count: z.coerce
+      .number({ message: 'Enter a number.' })
+      .int('Whole numbers only.')
+      .min(0, 'Must be 0 or more.'),
+  })
+  .strict()
+
+const formHandler = async function (data: {
+  keyRef: string
+  product: string
+  period: RateLimitPeriod
+  limit_count: number | string
+}) {
+  const sep = data.keyRef.indexOf(':')
+  const source = data.keyRef.slice(0, sep) as RateLimitSource
+  const apiKeyId = data.keyRef.slice(sep + 1)
+
+  await upsertRateLimit({
+    api_key_id: apiKeyId,
+    source,
+    product: data.product,
+    period: data.period,
+    limit_count: Number(data.limit_count),
+  })
+  emit('saved')
+}
+</script>
+
+<template>
+  <FormCard
+    :form-data="formModel"
+    :validation-schema="validationSchema"
+    :formDataHandler="formHandler"
+    @cancel="emit('cancel')"
+    v-slot="{ formData, getStatus, getError, loading }"
+  >
+    <Select
+      id="rate-limit-key"
+      label="API key"
+      :options="keyOptions"
+      v-model="formData.keyRef"
+      :validationStatus="getStatus('keyRef')"
+      :validationMessage="getError('keyRef')"
+      :disabled="loading || isEdit"
+      :instruction="
+        isEdit ? 'The key cannot be changed — delete and recreate to move the limit.' : undefined
+      "
+      :tabindex="1"
+      required
+    />
+    <Select
+      id="rate-limit-product"
+      label="Product"
+      :options="productOptions"
+      v-model="formData.product"
+      :validationStatus="getStatus('product')"
+      :validationMessage="getError('product')"
+      :disabled="loading || isEdit"
+      :tabindex="2"
+      required
+    />
+    <Select
+      id="rate-limit-period"
+      label="Window"
+      :options="periodOptions"
+      v-model="formData.period"
+      :validationStatus="getStatus('period')"
+      :validationMessage="getError('period')"
+      :disabled="loading"
+      :tabindex="3"
+      required
+    />
+    <Input
+      id="rate-limit-count"
+      label="Limit (billable events per window)"
+      type="number"
+      v-model="formData.limit_count"
+      :validationStatus="getStatus('limit_count')"
+      :validationMessage="getError('limit_count')"
+      :disabled="loading"
+      instruction="Counted per organisation, not per key. 0 blocks all calls."
+      :tabindex="4"
+      required
+    />
+  </FormCard>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,6 +14,7 @@ import MapsetListView from '@/views/MapsetListView.vue'
 import JobListView from '@/views/JobListView.vue'
 import SessionListView from '@/views/SessionListView.vue'
 import UserListView from '@/views/UserListView.vue'
+import RateLimitListView from '@/views/RateLimitListView.vue'
 import Login from '@/views/auth/Login.vue'
 import Callback from '@/views/auth/Callback.vue'
 import NoAccess from '@/views/auth/403.vue'
@@ -87,6 +88,12 @@ const router = createRouter({
       name: 'sessions',
       path: '/session/:id?',
       component: SessionListView,
+    },
+
+    {
+      name: 'rate-limits',
+      path: '/rate-limit/:id?',
+      component: RateLimitListView,
     },
   ],
 })

--- a/src/services/fundermaps/endpoints/management/rate-limit.ts
+++ b/src/services/fundermaps/endpoints/management/rate-limit.ts
@@ -1,0 +1,40 @@
+import { del, get, put } from '../../client'
+import type {
+  IRateLimit,
+  IRateLimitKey,
+  RateLimitPeriod,
+  RateLimitSource,
+} from '../../interfaces/IRateLimit'
+
+// Mirror the values the Webservice enforces against (api side: routes/product.ts
+// rateLimit(<product>) + rate-limit.ts). Used to drive the form selects.
+export const RATE_LIMIT_PRODUCTS = ['analysis3', 'risk3', 'light3', 'statistics3'] as const
+export const RATE_LIMIT_PERIODS: RateLimitPeriod[] = ['day', 'month']
+
+export const getRateLimits = async function getRateLimits(): Promise<IRateLimit[]> {
+  return await get({ endpoint: 'management/rate-limit' })
+}
+
+export const getRateLimitKeys = async function getRateLimitKeys(): Promise<IRateLimitKey[]> {
+  return await get({ endpoint: 'management/rate-limit/keys' })
+}
+
+export const upsertRateLimit = async function upsertRateLimit(body: {
+  api_key_id: string
+  source: RateLimitSource
+  product: string
+  period: RateLimitPeriod
+  limit_count: number
+}): Promise<IRateLimit> {
+  return await put({ endpoint: 'management/rate-limit', body })
+}
+
+export const deleteRateLimit = async function deleteRateLimit(
+  source: RateLimitSource,
+  apiKeyId: string,
+  product: string,
+) {
+  return await del({
+    endpoint: `management/rate-limit/${source}/${encodeURIComponent(apiKeyId)}/${product}`,
+  })
+}

--- a/src/services/fundermaps/interfaces/IRateLimit.ts
+++ b/src/services/fundermaps/interfaces/IRateLimit.ts
@@ -1,0 +1,24 @@
+export type RateLimitSource = 'ba' | 'legacy'
+export type RateLimitPeriod = 'day' | 'month'
+
+/** A configured per-(API key, product) billing-event limit. */
+export interface IRateLimit {
+  api_key_id: string
+  source: RateLimitSource
+  product: string
+  period: RateLimitPeriod
+  limit_count: number
+  created_at: string | null
+  updated_at: string | null
+}
+
+/** A selectable API key for the limit picker (from both key tables). */
+export interface IRateLimitKey {
+  api_key_id: string
+  source: RateLimitSource
+  name: string | null
+  enabled: boolean
+  expires_at: string | null
+  organization_id: string | null
+  organization_name: string | null
+}

--- a/src/views/RateLimitListView.vue
+++ b/src/views/RateLimitListView.vue
@@ -1,0 +1,294 @@
+<script setup lang="ts">
+import { computed, onBeforeMount, ref, type Ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import MainWrapper from '@/components/Layout/MainWrapper.vue'
+import Drawer from '@/components/Layout/Drawer.vue'
+import Table from '@/components/Common/Table.vue'
+import Alert from '@/components/Common/Alert.vue'
+import Button from '@/components/Common/Buttons/Button.vue'
+import Badge from '@/components/Common/Badge.vue'
+import MonoBadge from '@/components/Common/MonoBadge.vue'
+import Input from '@/components/Common/Inputs/Input.vue'
+import RateLimitForm from '@/components/Management/Forms/RateLimitForm.vue'
+import PlusIcon from '@assets/svg/icons/plus.svg?component'
+
+import {
+  deleteRateLimit,
+  getRateLimitKeys,
+  getRateLimits,
+} from '@/services/fundermaps/endpoints/management/rate-limit'
+import type { IRateLimit, IRateLimitKey } from '@/services/fundermaps/interfaces/IRateLimit'
+import { formatDate } from '@/utils/date'
+import { useFlash } from '@/composables/useFlash'
+import { useListResource } from '@/composables/useListResource'
+import { getErrorMessage } from '@/services/fundermaps/errors'
+
+// The table has a composite PK (source, api_key_id, product); synthesise a flat
+// `id` from it so the shared list/Table plumbing (selection, URL sync) works.
+type RateLimitRow = IRateLimit & { id: string }
+const rowId = (r: IRateLimit) => `${r.source}:${r.api_key_id}:${r.product}`
+
+const route = useRoute()
+const router = useRouter()
+
+const showCreate = ref(false)
+const deleting = ref(false)
+const actionError = ref<string | null>(null)
+const { message: actionSuccess, flash: flashSuccess } = useFlash()
+
+// Key metadata (org name, key name) for labelling rows. Non-fatal if it fails —
+// rows fall back to the raw api_key_id.
+const keys: Ref<IRateLimitKey[]> = ref([])
+const keyMap = computed<Map<string, IRateLimitKey>>(() => {
+  const m = new Map<string, IRateLimitKey>()
+  for (const k of keys.value) m.set(`${k.source}:${k.api_key_id}`, k)
+  return m
+})
+const keyOf = (r: { source: string; api_key_id: string }) =>
+  keyMap.value.get(`${r.source}:${r.api_key_id}`) ?? null
+const keyLabel = (r: { source: string; api_key_id: string }) =>
+  keyOf(r)?.name ?? r.api_key_id
+const orgLabel = (r: { source: string; api_key_id: string }) =>
+  keyOf(r)?.organization_name ?? '—'
+
+const columns = [
+  { field: 'organization', title: 'Organisation' },
+  { field: 'key', title: 'API key' },
+  { field: 'product', title: 'Product', width: '8rem' },
+  { field: 'period', title: 'Window', width: '7rem' },
+  { field: 'limit_count', title: 'Limit', width: '7rem', align: 'right' as const },
+  { field: 'updated_at', title: 'Updated', width: '11rem' },
+]
+
+const {
+  rows,
+  loading,
+  error,
+  search,
+  record,
+  filteredRows,
+  refresh: refreshList,
+  select: handleSelect,
+  selectById,
+  selectFirst: selectFirstRow,
+} = useListResource<RateLimitRow>({
+  fetch: async () => (await getRateLimits()).map((r) => ({ ...r, id: rowId(r) })),
+  filter: (r, q) =>
+    r.product.toLowerCase().includes(q) ||
+    r.api_key_id.toLowerCase().includes(q) ||
+    keyLabel(r).toLowerCase().includes(q) ||
+    orgLabel(r).toLowerCase().includes(q),
+  onSelect: () => {
+    showCreate.value = false
+    actionError.value = null
+    actionSuccess.value = null
+  },
+  routeId: () => (typeof route.params.id === 'string' ? route.params.id : undefined),
+  syncRoute: (id) => router.replace({ name: 'rate-limits', params: { id }, query: route.query }),
+  immediate: false,
+})
+
+const loadKeys = async function () {
+  try {
+    keys.value = await getRateLimitKeys()
+  } catch {
+    // Non-fatal — table falls back to raw api_key_id labels.
+  }
+}
+
+onBeforeMount(async () => {
+  await Promise.all([refreshList(), loadKeys()])
+  const id = typeof route.params.id === 'string' ? route.params.id : undefined
+  if (id && rows.value.some((r) => r.id === id)) selectById(id)
+  else selectFirstRow()
+})
+
+const drawerMode = computed<'create' | 'details' | null>(() => {
+  if (showCreate.value) return 'create'
+  if (record.value) return 'details'
+  return null
+})
+
+const periodLabel = (p: string) => (p === 'day' ? 'Per day' : p === 'month' ? 'Per month' : p)
+
+const handleOpenCreate = function () {
+  record.value = null
+  showCreate.value = true
+}
+
+const handleCreated = async function () {
+  await Promise.all([refreshList(), loadKeys()])
+  flashSuccess('Rate limit saved.')
+}
+
+const handleDismissCreate = function () {
+  showCreate.value = false
+  if (!record.value) selectFirstRow()
+}
+
+const handleEdited = async function () {
+  if (!record.value) return
+  const id = record.value.id
+  await refreshList()
+  if (rows.value.some((r) => r.id === id)) selectById(id)
+  else selectFirstRow()
+  flashSuccess('Rate limit updated.')
+}
+
+const handleDelete = async function () {
+  if (!record.value) return
+  const r = record.value
+  if (
+    !confirm(
+      `Remove the ${r.product} limit for "${orgLabel(r)}" (key ${keyLabel(r)})? The key becomes unlimited for this product.`,
+    )
+  )
+    return
+
+  try {
+    deleting.value = true
+    actionError.value = null
+    await deleteRateLimit(r.source, r.api_key_id, r.product)
+    record.value = null
+    await refreshList()
+    selectFirstRow()
+    flashSuccess('Rate limit removed.')
+  } catch (e) {
+    actionError.value = getErrorMessage(e) ?? 'Failed to remove rate limit.'
+  } finally {
+    deleting.value = false
+  }
+}
+</script>
+
+<template>
+  <MainWrapper>
+    <header class="mb-4 flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-grey-800">Rate limits</h2>
+        <p class="mt-0.5 text-sm text-grey-700">
+          Per-(API key, product) caps on billable Webservice calls. Overage is counted per
+          organisation.
+        </p>
+      </div>
+      <Button lg label="Add limit" @click="handleOpenCreate">
+        <template #before>
+          <PlusIcon class="aspect-square h-4 w-4" aria-hidden="true" />
+        </template>
+      </Button>
+    </header>
+
+    <div class="mb-3 flex items-center gap-3">
+      <div class="w-72">
+        <Input
+          id="rate-limit-search"
+          v-model="search"
+          type="search"
+          placeholder="Search by organisation, key or product…"
+        />
+      </div>
+      <span class="text-xs text-grey-700">{{ filteredRows.length }} of {{ rows.length }}</span>
+    </div>
+
+    <Alert v-if="error" :closeable="true" class="mb-3" @close="error = false">
+      An error occurred while trying to retrieve the rate limits.
+    </Alert>
+
+    <Table
+      :rows="filteredRows"
+      :columns="columns"
+      :loading="loading"
+      :selectedId="record?.id"
+      emptyMessage="No rate limits configured."
+      @select="handleSelect"
+    >
+      <template #organization="{ row }">
+        <span class="text-grey-800">{{ orgLabel(row) }}</span>
+      </template>
+      <template #key="{ row }">
+        <span class="text-grey-700">{{ keyLabel(row) }}</span>
+        <Badge v-if="row.source === 'legacy'" variant="warning" class="ml-2">legacy</Badge>
+      </template>
+      <template #product="{ row }">
+        <MonoBadge :value="row.product" />
+      </template>
+      <template #period="{ row }">
+        <span class="text-grey-700">{{ periodLabel(row.period) }}</span>
+      </template>
+      <template #limit_count="{ row }">
+        <span class="font-mono text-grey-800">{{ row.limit_count.toLocaleString() }}</span>
+      </template>
+      <template #updated_at="{ row }">{{ formatDate(row.updated_at) }}</template>
+    </Table>
+
+    <template #aside>
+      <Drawer>
+        <template #title>
+          <template v-if="drawerMode === 'create'">New rate limit</template>
+          <template v-else-if="drawerMode === 'details'">Rate limit</template>
+          <template v-else>Rate limit</template>
+        </template>
+
+        <template v-if="drawerMode === 'details'" #actions>
+          <Button danger label="Remove" :loading="deleting" @click="handleDelete" />
+        </template>
+
+        <!-- Create -->
+        <div v-if="drawerMode === 'create'">
+          <Alert v-if="!keys.length" type="warning" class="mb-3">
+            No API keys found to attach a limit to.
+          </Alert>
+          <RateLimitForm v-else :keys="keys" @saved="handleCreated" @cancel="handleDismissCreate" />
+        </div>
+
+        <!-- Details + edit -->
+        <div v-else-if="drawerMode === 'details' && record" class="space-y-5">
+          <Alert v-if="actionError" :closeable="true" @close="actionError = null">
+            {{ actionError }}
+          </Alert>
+          <Alert v-if="actionSuccess" type="success" :closeable="true" @close="actionSuccess = null">
+            {{ actionSuccess }}
+          </Alert>
+
+          <dl class="grid grid-cols-[8rem_1fr] gap-x-4 gap-y-2 text-sm">
+            <dt class="text-grey-700">Organisation</dt>
+            <dd class="text-grey-800">{{ orgLabel(record) }}</dd>
+            <dt class="text-grey-700">API key</dt>
+            <dd class="text-grey-800">
+              {{ keyLabel(record) }}
+              <Badge v-if="record.source === 'legacy'" variant="warning" class="ml-1">legacy</Badge>
+            </dd>
+            <dt class="text-grey-700">Key ID</dt>
+            <dd><MonoBadge :value="record.api_key_id" /></dd>
+            <dt class="text-grey-700">Product</dt>
+            <dd><MonoBadge :value="record.product" /></dd>
+            <dt class="text-grey-700">Created</dt>
+            <dd class="text-grey-800">{{ formatDate(record.created_at) }}</dd>
+            <dt class="text-grey-700">Updated</dt>
+            <dd class="text-grey-800">{{ formatDate(record.updated_at) }}</dd>
+          </dl>
+
+          <section class="border-t border-grey-200 pt-5">
+            <h6 class="mb-2 text-xs font-semibold uppercase tracking-wide text-grey-700">
+              Update limit
+            </h6>
+            <RateLimitForm
+              :key="record.id"
+              :keys="keys"
+              :record="record"
+              @saved="handleEdited"
+            />
+          </section>
+        </div>
+
+        <div
+          v-else
+          class="flex h-full items-center justify-center text-center text-sm text-grey-700"
+        >
+          Select a rate limit, or add one.
+        </div>
+      </Drawer>
+    </template>
+  </MainWrapper>
+</template>


### PR DESCRIPTION
## What

Adds an admin screen to configure the FunderMapsWebservice per-(API key, product) billing-event **rate limits** — until now these had to be hand-inserted as SQL. Pairs with the new backend surface in `Laixer/FunderMapsApi#77` and backs `Laixer/FunderMapsWebservice#8`.

## UX

- **Rate limits** nav item under *Platform*.
- List view (mirrors Sessions/Users): table of configured limits with **organisation**, **key**, **product**, **window**, **limit**, **updated**; searchable; legacy keys badged.
- Drawer:
  - **Add limit** — pick an API key (org + name labelled, from `/rate-limit/keys`), product, window (day/month), and count.
  - **Details + edit** — change window/limit (key + product are the PK, so they're locked — delete & recreate to move a limit). Remove button.
- Built on the idempotent `PUT` upsert, so create and edit share one path.

## Files

- `services/fundermaps/endpoints/management/rate-limit.ts` + `interfaces/IRateLimit.ts`
- `views/RateLimitListView.vue`
- `components/Management/Forms/RateLimitForm.vue`
- `router/index.ts`, `components/Layout/Sidebar.vue`

## Semantics note

Limits are keyed **per API key** but overage is **counted per organisation** (the Webservice counts `product_tracker` rows per org). The form states this explicitly. Matches current Webservice behavior; longer-term fix tracked in `Laixer/FunderMapsWebservice#16`.

## Test

- `pnpm type-check` ✅
- `pnpm lint` ✅
- `pnpm build` ✅

> ⚠️ Depends on `Laixer/FunderMapsApi#77` being deployed — the `/api/management/rate-limit*` endpoints don't exist until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)